### PR TITLE
Remove ExtJS3 dependencies

### DIFF
--- a/onprc_billing/resources/views/invoiceEstimate.html
+++ b/onprc_billing/resources/views/invoiceEstimate.html
@@ -142,8 +142,8 @@
                         ],
                         parameters: {
                             numDays: interval,
-                            startDate: startDate.format('Y-m-d'),
-                            endDate: endDate.format('Y-m-d')
+                            startDate: Ext4.Date.format(startDate, 'Y-m-d'),
+                            endDate: Ext4.Date.format(endDate, 'Y-m-d')
                         },
                         aggregates: [
                             {column: 'totalCost', type: LABKEY.AggregateTypes.SUM, label: 'Total'}
@@ -163,8 +163,8 @@
                             LABKEY.Filter.create('project', project, LABKEY.Filter.Types.EQUAL)
                         ],
                         parameters: {
-                            startDate: startDate.format('Y-m-d'),
-                            endDate: endDate.format('Y-m-d')
+                            startDate: Ext4.Date.format(startDate, 'Y-m-d'),
+                            endDate: Ext4.Date.format(endDate, 'Y-m-d')
                         },
                         aggregates: [
                             {column: 'totalCost', type: LABKEY.AggregateTypes.SUM, label: 'Total'}
@@ -184,8 +184,8 @@
                             LABKEY.Filter.create('project', project, LABKEY.Filter.Types.EQUAL)
                         ],
                         parameters: {
-                            startDate: startDate.format('Y-m-d'),
-                            endDate: endDate.format('Y-m-d')
+                            startDate: Ext4.Date.format(startDate, 'Y-m-d'),
+                            endDate: Ext4.Date.format(endDate, 'Y-m-d')
                         },
                         aggregates: [
                             {column: 'totalCost', type: LABKEY.AggregateTypes.SUM, label: 'Total'}
@@ -205,8 +205,8 @@
                             LABKEY.Filter.create('project', project, LABKEY.Filter.Types.EQUAL)
                         ],
                         parameters: {
-                            startDate: startDate.format('Y-m-d'),
-                            endDate: endDate.format('Y-m-d')
+                            startDate: Ext4.Date.format(startDate, 'Y-m-d'),
+                            endDate: Ext4.Date.format(endDate, 'Y-m-d')
                         },
                         aggregates: [
                             {column: 'totalCost', type: LABKEY.AggregateTypes.SUM, label: 'Total'}
@@ -227,8 +227,8 @@
                         ],
                         parameters: {
                             numDays: interval,
-                            startDate: startDate.format('Y-m-d'),
-                            endDate: endDate.format('Y-m-d')
+                            startDate: Ext4.Date.format(startDate, 'Y-m-d'),
+                            endDate: Ext4.Date.format(endDate, 'Y-m-d')
                         },
                         aggregates: [
                             {column: 'totalCost', type: LABKEY.AggregateTypes.SUM, label: 'Total'}
@@ -248,8 +248,8 @@
                             LABKEY.Filter.create('project', project, LABKEY.Filter.Types.EQUAL)
                         ],
                         parameters: {
-                            startDate: startDate.format('Y-m-d'),
-                            endDate: endDate.format('Y-m-d')
+                            startDate: Ext4.Date.format(startDate, 'Y-m-d'),
+                            endDate: Ext4.Date.format(endDate, 'Y-m-d')
                         },
                         aggregates: [
                             {column: 'totalCost', type: LABKEY.AggregateTypes.SUM, label: 'Total'}

--- a/onprc_billing/resources/views/invoiceRunDetails.html
+++ b/onprc_billing/resources/views/invoiceRunDetails.html
@@ -63,8 +63,8 @@ Ext4.onReady(function(){
 
                                 var startDate = rec.get('billingPeriodStart') ? rec.get('billingPeriodStart').clearTime() : null;
                                 var endDate = rec.get('billingPeriodEnd') ? rec.get('billingPeriodEnd').clearTime() : null;
-                                var startDateString = startDate ? startDate.format('Y-m-d') : '';
-                                var endDateString = endDate ? endDate.format('Y-m-d') : '';
+                                var startDateString = startDate ? Ext4.Date.format(startDate, 'Y-m-d') : '';
+                                var endDateString = endDate ? Ext4.Date.format(endDate, 'Y-m-d') : '';
 
                                 var interval = 0;
                                 if (startDate && endDate){

--- a/onprc_billing/resources/web/onprc_billing/window/ChangeBillDateWindow.js
+++ b/onprc_billing/resources/web/onprc_billing/window/ChangeBillDateWindow.js
@@ -135,7 +135,7 @@ Ext4.define('ONPRC_Billing.window.ChangeBillDateWindow', {
         }
 
         if (this.lastInvoiceDate && date.getTime() < this.lastInvoiceDate.getTime()){
-            Ext4.Msg.alert('Error', 'Must supply a date that is after the last invoice date of: ' + this.lastInvoiceDate.format('Y-m-d'));
+            Ext4.Msg.alert('Error', 'Must supply a date that is after the last invoice date of: ' + Ext4.Date.format(this.lastInvoiceDate, 'Y-m-d'));
             return;
         }
 

--- a/onprc_ehr/resources/views/historyExport.html
+++ b/onprc_ehr/resources/views/historyExport.html
@@ -85,8 +85,8 @@
                             'rs:ClearSession': true,
                             Redacted: redacted ? 'true' : 'false',
                             AnimalId: val,
-                            minDate: mindate1.format('Y-m-d'),      //Added: 11-18-2016 R.Blasa
-                            maxDate: maxdate1.format('Y-m-d')
+                            minDate: Ext4.Date.format(mindate1, 'Y-m-d'),      //Added: 11-18-2016 R.Blasa
+                            maxDate: Ext4.Date.format(maxdate1, 'Y-m-d')
                         });
 
                         //url += '&rs:Format=PDF'

--- a/onprc_ehr/resources/views/printableReports.html
+++ b/onprc_ehr/resources/views/printableReports.html
@@ -293,7 +293,7 @@
                                 return;
                             }
 
-                            params['TreatmentDate'] = date.format(LABKEY.extDefaultDateFormat);
+                            params['TreatmentDate'] = Ext4.Date.format(date, ABKEY.extDefaultDateFormat);
                             params['NumDays'] = 1;
                             params['Category'] = 'Clinical';
 
@@ -384,7 +384,7 @@
                                 return;
                             }
 
-                            params['TreatmentDate'] = date.format(LABKEY.extDefaultDateFormat);
+                            params['TreatmentDate'] = Ext4.Date.format(date, LABKEY.extDefaultDateFormat);
                             params['NumDays'] = 1;
                             params['Category'] = 'Diet';
 
@@ -542,7 +542,7 @@
                                 return;
                             }
 
-                            params['TreatmentDate'] = date.format(LABKEY.extDefaultDateFormat);
+                            params['TreatmentDate'] = Ext4.Date.format(date, LABKEY.extDefaultDateFormat);
                             params['NumDays'] = 1;
                             params['Category'] = 'Surgical';
 

--- a/onprc_ehr/resources/web/onprc_ehr/panel/AddScheduledTreatmentPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/AddScheduledTreatmentPanel.js
@@ -100,7 +100,7 @@ Ext4.define('onprc_ehr.panel.AddScheduledTreatmentPanel', {
 
         var filterArray = [];
 
-        filterArray.push(LABKEY.Filter.create('date', date.format(LABKEY.extDefaultDateFormat), LABKEY.Filter.Types.DATE_EQUAL));
+        filterArray.push(LABKEY.Filter.create('date', Ext4.Date.format(date, LABKEY.extDefaultDateFormat), LABKEY.Filter.Types.DATE_EQUAL));
         filterArray.push(LABKEY.Filter.create('taskid', null, LABKEY.Filter.Types.ISBLANK));
         filterArray.push(LABKEY.Filter.create('treatmentStatus', null, LABKEY.Filter.Types.ISBLANK));
 
@@ -135,7 +135,7 @@ Ext4.define('onprc_ehr.panel.AddScheduledTreatmentPanel', {
             queryName: 'treatmentSchedule',
             parameters: {
                 NumDays: 1,
-                StartDate: date.format(LABKEY.extDefaultDateFormat)
+                StartDate: Ext4.Date.format(date, LABKEY.extDefaultDateFormat)
             },
             sort: 'date,Id/curlocation/room_sortValue,Id/curlocation/cage_sortValue,Id',
             columns: 'primaryKey,lsid,treatmentid,Id,date,project,meaning,code,qualifier,route,concentration,conc_units,amount,amount_units,dosage,dosage_units,volume,vol_units,remark,category,chargetype',

--- a/onprc_ehr/resources/web/onprc_ehr/panel/AnimalDetailsCasePanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/AnimalDetailsCasePanel.js
@@ -235,7 +235,7 @@ Ext4.define('onprc_ehr.panel.AnimalDetailsCasePanel', {
                 interval = interval + ' days ago';
             }
 
-            text = row.weight + ' kg, ' + date.format('Y-m-d') + (!Ext4.isEmpty(interval) ? ' (' + interval + ')' : '');
+            text = row.weight + ' kg, ' + Ext4.Date.format(date, 'Y-m-d') + (!Ext4.isEmpty(interval) ? ' (' + interval + ')' : '');
         }
 
         toSet['weights'] = text;
@@ -279,12 +279,12 @@ Ext4.define('onprc_ehr.panel.AnimalDetailsCasePanel', {
                     if (date && (!enddate || enddate.getTime() > (new Date()).getTime())){
                         var reviewdate = row.reviewdate ? LDK.ConvertUtils.parseDate(row.reviewdate) : null;
                         if (!reviewdate || Ext4.Date.clearTime(reviewdate).getTime() <= Ext4.Date.clearTime(new Date()).getTime()){
-                            text = text + ' (' + date.format('Y-m-d') + ')';
+                            text = text + ' (' + Ext4.Date.format(date, 'Y-m-d') + ')';
 
                             values.push(text);
                         }
                         else if (reviewdate && Ext4.Date.clearTime(reviewdate).getTime() > Ext4.Date.clearTime(new Date()).getTime()){
-                            text = text + ' - None (Reopens: '  + reviewdate.format('Y-m-d') + ')';
+                            text = text + ' - None (Reopens: '  + Ext4.Date.format(reviewdate, 'Y-m-d') + ')';
                             values.push(text);
                         }
                     }

--- a/onprc_ehr/resources/web/onprc_ehr/panel/BloodSummaryPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/BloodSummaryPanel.js
@@ -171,7 +171,7 @@ Ext4.define('ONPRC.panel.BloodSummaryPanel', {
         Ext4.each(results.rows, function(row, idx){
             //capture the current day's amount
             var rowDate = new Date(row.date.value);
-            if (rowDate && rowDate.format(LABKEY.extDefaultDateFormat) == (new Date()).format(LABKEY.extDefaultDateFormat)){
+            if (rowDate && Ext4.Date.format(rowDate, LABKEY.extDefaultDateFormat) == Ext4.Date.format(new Date(), LABKEY.extDefaultDateFormat)){
                 currentRow = row;
             }
 
@@ -198,7 +198,7 @@ Ext4.define('ONPRC.panel.BloodSummaryPanel', {
                 newRow.isHidden = {value: true};
                 var date = LDK.ConvertUtils.parseDate(row.date.value);
                 date = Ext4.Date.add(date, Ext4.Date.DAY, 1);
-                newRow.date.value = date.format('Y/m/d H:i:s');
+                newRow.date.value = Ext4.Date.format(date, 'Y/m/d H:i:s');
                 newRows.push(newRow);
             }
         }, this);
@@ -233,11 +233,11 @@ Ext4.define('ONPRC.panel.BloodSummaryPanel', {
                         hoverText: function(row){
                             var lines = [];
 
-                            lines.push('Date: ' + row.date.format(LABKEY.extDefaultDateFormat));
+                            lines.push('Date: ' + Ext4.Date.format(row.date, LABKEY.extDefaultDateFormat));
                             lines.push('Drawn on this Date: ' + row.quantity);
                             lines.push('Volume Available on this Date: ' + LABKEY.Utils.roundNumber(row.allowableDisplay, 1) + ' mL');
 
-                            lines.push('Current Weight: ' + row.mostRecentWeight + ' kg (' + row.mostRecentWeightDate.format(LABKEY.extDefaultDateFormat) + ')');
+                            lines.push('Current Weight: ' + row.mostRecentWeight + ' kg (' + Ext4.Date.format(row.mostRecentWeightDate, LABKEY.extDefaultDateFormat) + ')');
 
                             lines.push('Drawn in Previous ' + row.blood_draw_interval + ' days: ' + LABKEY.Utils.roundNumber(row.bloodPrevious, 1));
                             lines.push('Drawn in Next ' + row.blood_draw_interval + ' days: ' + LABKEY.Utils.roundNumber(row.bloodFuture, 1));

--- a/onprc_ehr/resources/web/onprc_ehr/panel/NarrowSnapshotPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/NarrowSnapshotPanel.js
@@ -25,7 +25,11 @@ Ext4.define('onprc_ehr.panel.NarrowSnapshotPanel', {
         var firstCol = items[0].items[1].items[0];
         var secondCol = items[0].items[1].items[1];
         var thirdCol = items[0].items[1].items[2];
-        items[0].items[1].items.remove(secondCol);
+
+        var index = items[0].items[1].items.indexOf(secondCol);
+        if (index !== -1) {
+            items[0].items[1].items = items[0].items[1].items.splice(index, 1);
+        }
 
         firstCol.columnWidth = 0.45;
         thirdCol.columnWidth = 0.55;

--- a/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
@@ -279,12 +279,12 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
                     if (date && (!enddate || enddate.getTime() > (new Date()).getTime())){
                         var reviewdate = row.reviewdate ? LDK.ConvertUtils.parseDate(row.reviewdate) : null;
                         if (!reviewdate || Ext4.Date.clearTime(reviewdate).getTime() <= Ext4.Date.clearTime(new Date()).getTime()){
-                            text = text + ' (' + date.format('Y-m-d') + ')';
+                            text = text + ' (' + Ext4.Date.format(date, 'Y-m-d') + ')';
 
                             values.push(text);
                         }
                         else if (reviewdate && Ext4.Date.clearTime(reviewdate).getTime() > Ext4.Date.clearTime(new Date()).getTime()){
-                            text = text + ' - None (Reopens: '  + reviewdate.format('Y-m-d') + ')';
+                            text = text + ' - None (Reopens: '  + Ext4.Date.format(reviewdate, 'Y-m-d') + ')';
                             values.push(text);
                         }
                     }
@@ -313,7 +313,7 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
         if (results)
         {
              var sDate = LDK.ConvertUtils.parseDate(results[0].ExpectedDelivery);
-              toSet['pregnancyInfo']   = sDate.format('Y-m-d');
+              toSet['pregnancyInfo']   = Ext4.Date.format(sDate, 'Y-m-d');
         }
         else
         {
@@ -378,7 +378,7 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
             }, this);
                 //Modified: 8-29-2016 R.Blasa Include time within the date field
             Ext4.each(rows, function(r){
-                text.push('<tr><td nowrap>' + r.weight + ' kg' + '</td><td style="padding-left: 5px;" nowrap>' + r.date.format('Y-m-d H:i') + '</td><td style="padding-left: 5px;" nowrap>' + (Ext4.isDefined(r.interval) ? ' (' + r.interval + ')' : '') + "</td></tr>");
+                text.push('<tr><td nowrap>' + r.weight + ' kg' + '</td><td style="padding-left: 5px;" nowrap>' + Ext4.Date.format(r.date, 'Y-m-d H:i') + '</td><td style="padding-left: 5px;" nowrap>' + (Ext4.isDefined(r.interval) ? ' (' + r.interval + ')' : '') + "</td></tr>");
             }, this);
         }
 

--- a/onprc_ehr/resources/web/onprc_ehr/window/BulkBloodDrawWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/BulkBloodDrawWindow.js
@@ -266,7 +266,7 @@ Ext4.define('ONPRC_EHR.window.BulkBloodDrawWindow', {
         }
 
         timeStr = Ext4.String.leftPad(timeStr, 5, '0'); //expect: HH:mm
-        var ret = LDK.ConvertUtils.parseDate(date.format(LABKEY.extDefaultDateFormat) + ' ' + timeStr);
+        var ret = LDK.ConvertUtils.parseDate(Ext4.Date.format(date, LABKEY.extDefaultDateFormat) + ' ' + timeStr);
         if (!ret){
             errors.push('Row ' + rowIdx + ': invalid time: ' + timeStr);
         }

--- a/onprc_ehr/resources/web/onprc_ehr/window/BulkChangeCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/BulkChangeCasesWindow.js
@@ -98,7 +98,7 @@ Ext4.define('ONPRC_EHR.window.BulkChangeCasesWindow', {
 
             toAdd.push({
                 xtype: 'displayfield',
-                value: LDK.ConvertUtils.parseDate(caseRow.date).format(LABKEY.extDefaultDateFormat)
+                value: Ext4.Date.format(LDK.ConvertUtils.parseDate(caseRow.date), LABKEY.extDefaultDateFormat)
             });
 
             toAdd.push({

--- a/onprc_ehr/resources/web/onprc_ehr/window/BulkSerologyScanWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/BulkSerologyScanWindow.js
@@ -274,7 +274,7 @@ Ext4.define('ONPRC_EHR.window.BulkSerologyScanWindow', {
         }
 
         timeStr = Ext4.String.leftPad(timeStr, 5, '0'); //expect: HH:mm
-        var ret = LDK.ConvertUtils.parseDate(date.format(LABKEY.extDefaultDateFormat) + ' ' + timeStr);
+        var ret = LDK.ConvertUtils.parseDate(Ext4.Date.format(date, LABKEY.extDefaultDateFormat) + ' ' + timeStr);
         if (!ret){
             errors.push('Row ' + rowIdx + ': invalid time: ' + timeStr);
         }

--- a/onprc_ehr/resources/web/onprc_ehr/window/BulkSerologyVirologyWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/BulkSerologyVirologyWindow.js
@@ -273,7 +273,7 @@ Ext4.define('ONPRC_EHR.window.BulkSerology_VirologyWindow', {
         }
 
         timeStr = Ext4.String.leftPad(timeStr, 5, '0'); //expect: HH:mm
-        var ret = LDK.ConvertUtils.parseDate(date.format(LABKEY.extDefaultDateFormat) + ' ' + timeStr);
+        var ret = LDK.ConvertUtils.parseDate(Ext4.Date.format(date, LABKEY.extDefaultDateFormat) + ' ' + timeStr);
         if (!ret){
             errors.push('Row ' + rowIdx + ': invalid time: ' + timeStr);
         }

--- a/onprc_ehr/resources/web/onprc_ehr/window/BulkStrokeRoundsWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/BulkStrokeRoundsWindow.js
@@ -329,7 +329,7 @@ Ext4.define('ONPRC_EHR.window.BulkStrokeRoundsWindow', {
         }
 
         timeStr = Ext4.String.leftPad(timeStr, 5, '0'); //expect: HH:mm
-        var ret = LDK.ConvertUtils.parseDate(date.format(LABKEY.extDefaultDateFormat) + ' ' + timeStr);
+        var ret = LDK.ConvertUtils.parseDate(Ext4.util.Format.date(date, LABKEY.extDefaultDateFormat) + ' ' + timeStr);
         if (!ret){
             errors.push('Row ' + rowIdx + ': invalid time: ' + timeStr);
         }

--- a/onprc_ehr/resources/web/onprc_ehr/window/CopyFromRunsTemplateWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/CopyFromRunsTemplateWindow.js
@@ -143,7 +143,7 @@ Ext4.define('ONPRC_EHR.window.CopyFromRunsTemplateWindow', {
                 width: 60
             });
             toAdd.push({
-                html: r.get('date').format(LABKEY.extDefaultDateTimeFormat),         //Modified 2-5-2015  to include date hour minutes
+                html: Ext4.Date.format(r.get('date'), LABKEY.extDefaultDateTimeFormat),         //Modified 2-5-2015  to include date hour minutes
                 width: 100
             });
             toAdd.push({

--- a/onprc_ehr/resources/web/onprc_ehr/window/MassBleedWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/MassBleedWindow.js
@@ -396,7 +396,7 @@ Ext4.define('ONPRC_EHR.window.MassBleedWindow', {
         }
 
         timeStr = Ext4.String.leftPad(timeStr, 5, '0'); //expect: HH:mm
-        var ret = LDK.ConvertUtils.parseDate(date.format(LABKEY.extDefaultDateFormat) + ' ' + timeStr);
+        var ret = LDK.ConvertUtils.parseDate(Ext4.Date.format(date, LABKEY.extDefaultDateFormat) + ' ' + timeStr);
         if (!ret){
             errors.push('Row ' + rowIdx + ': invalid time: ' + timeStr);
         }

--- a/onprc_ehr/resources/web/onprc_ehr/window/ONPRC_AddScheduledTreatmentWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/ONPRC_AddScheduledTreatmentWindow.js
@@ -146,7 +146,7 @@ Ext4.define('ONPRC_EHR.window.AddScheduledTreatmentWindow', {
 
         var filterArray = [];
 
-        filterArray.push(LABKEY.Filter.create('date', date.format(LABKEY.extDefaultDateFormat), LABKEY.Filter.Types.DATE_EQUAL));
+        filterArray.push(LABKEY.Filter.create('date', Ext4.Date.format(date, LABKEY.extDefaultDateFormat), LABKEY.Filter.Types.DATE_EQUAL));
         filterArray.push(LABKEY.Filter.create('taskid', null, LABKEY.Filter.Types.ISBLANK));
         filterArray.push(LABKEY.Filter.create('treatmentStatus', null, LABKEY.Filter.Types.ISBLANK));
               //Modified 7-4-2015 Blasa
@@ -186,7 +186,7 @@ Ext4.define('ONPRC_EHR.window.AddScheduledTreatmentWindow', {
             queryName: 'treatmentSchedule',
             parameters: {
                 NumDays: 1,
-                StartDate: date.format(LABKEY.extDefaultDateFormat)
+                StartDate: Ext4.Date.format(date, LABKEY.extDefaultDateFormat)
             },
             sort: 'date,Id/curlocation/room_sortValue,Id/curlocation/cage_sortValue,Id',
             columns: 'primaryKey,lsid,treatmentid,Id,date,project,meaning,code,qualifier,route,concentration,conc_units,amount,amount_units,dosage,dosage_units,volume,vol_units,remark,category,chargetype',


### PR DESCRIPTION
#### Rationale
ExtJS3 injected a format function into the JS date prototype object. We shouldn't rely on it being present anymore

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/56

#### Changes
* Stop using format function that ExtJS3 injected into date prototypes, update NavMenu to ExtJS4
