### PR TITLE
Switch to DisplayColumn.getFormattedHtml() and use HtmlString

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -1738,7 +1738,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdPLT"));
                             String id = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedValue(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedHtml(ctx) + "</a></span>");
                         }
 
                         @Override
@@ -1769,7 +1769,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdHCT"));
                             String id = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedValue(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedHtml(ctx) + "</a></span>");
                         }
 
                         @Override

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ObservationDisplayColumn.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ObservationDisplayColumn.java
@@ -15,18 +15,10 @@
  */
 package org.labkey.onprc_ehr.table;
 
-import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
-import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.view.template.ClientDependency;
-
-import java.io.IOException;
-import java.io.Writer;
-import java.util.Collections;
-import java.util.Set;
+import org.labkey.api.util.HtmlString;
 
 //Created: 9-8-2016 R.Blasa
 public class ObservationDisplayColumn extends DataColumn
@@ -37,10 +29,10 @@ public class ObservationDisplayColumn extends DataColumn
     }
 
     @Override
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
-        String result = super.getFormattedValue(ctx);
-        return result.replace("Vet Attention", "<span style=\"background-color: yellow;\">Vet Attention</span>");
+        String result = super.getFormattedHtml(ctx).toString();
+        return HtmlString.unsafe(result.replace("Vet Attention", "<span style=\"background-color: yellow;\">Vet Attention</span>"));
     }
 
 


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1602

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML