### PR TITLE
Make a minimal dev build easier via Artifactory

### DIFF
--- a/onprc_ehr/build.gradle
+++ b/onprc_ehr/build.gradle
@@ -11,5 +11,8 @@ dependencies
    modules("org.labkey.module:laboratory:${labkeyVersion}@module") { transitive = true }
    modules("org.labkey.module:LDK:${labkeyVersion}@module") { transitive = true }
    modules("org.labkey.module:dataintegration:${labkeyVersion}@module") { transitive = true }
-   modules("org.labkey.module:premium:${labkeyVersion}@module") { transitive = true }
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: 'published', depExtension: 'module')
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: 'published', depExtension: 'module')
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premium", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/onprc_ehr/build.gradle
+++ b/onprc_ehr/build.gradle
@@ -8,11 +8,8 @@ dependencies
 
    // Ensure that we have these modules, either from Artifactory or local source, even if they aren't direct dependencies
    // to make it easier to build a minimal set on a dev machine
-   modules("org.labkey.module:laboratory:${labkeyVersion}@module") { transitive = true }
-   modules("org.labkey.module:LDK:${labkeyVersion}@module") { transitive = true }
-   modules("org.labkey.module:dataintegration:${labkeyVersion}@module") { transitive = true }
-BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: 'published', depExtension: 'module')
-BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
-BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: 'published', depExtension: 'module')
-BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premium", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premium", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/onprc_ehr/build.gradle
+++ b/onprc_ehr/build.gradle
@@ -5,4 +5,11 @@ dependencies
    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
+
+   // Ensure that we have these modules, either from Artifactory or local source, even if they aren't direct dependencies
+   // to make it easier to build a minimal set on a dev machine
+   modules("org.labkey.module:laboratory:${labkeyVersion}@module") { transitive = true }
+   modules("org.labkey.module:LDK:${labkeyVersion}@module") { transitive = true }
+   modules("org.labkey.module:dataintegration:${labkeyVersion}@module") { transitive = true }
+   modules("org.labkey.module:premium:${labkeyVersion}@module") { transitive = true }
 }

--- a/sla/module.properties
+++ b/sla/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.sla.SLAModule
 SupportedDatabases: mssql
-ModuleDependencies: LDK, EHR
 ManageVersion: false


### PR DESCRIPTION
#### Rationale
We want devs to be building just the modules they're editing, but that requires improved dependency declarations

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/70

#### Changes
* Explicitly declare that we need more whole modules so they get pulled from Artifactory if they're not available locally.

* Don't double-declare dependency in modules.properties and build.gradle