### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/GeneticsCore/build.gradle
+++ b/GeneticsCore/build.gradle
@@ -2,4 +2,6 @@ import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/GeneticsCore/module.properties
+++ b/GeneticsCore/module.properties
@@ -1,3 +1,2 @@
 ModuleClass: org.labkey.GeneticsCore.GeneticsCoreModule
-ModuleDependencies: LDK, EHR
 ManageVersion: false

--- a/HormoneAssay/build.gradle
+++ b/HormoneAssay/build.gradle
@@ -4,4 +4,6 @@ dependencies {
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/HormoneAssay/module.properties
+++ b/HormoneAssay/module.properties
@@ -1,3 +1,2 @@
 ModuleClass: org.labkey.hormoneassay.HormoneAssayModule
-ModuleDependencies: LDK, Laboratory
 ManageVersion: false

--- a/ogasync/build.gradle
+++ b/ogasync/build.gradle
@@ -1,5 +1,9 @@
-import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.BuildUtils
 
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:onprc_ehr", depProjectConfig: "published", depExtension: "module")
 }

--- a/ogasync/module.properties
+++ b/ogasync/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.ogasync.OGASyncModule
-ModuleDependencies: LDK, EHR, ONPRC_EHR
 SupportedDatabases: mssql
 ManageVersion: false

--- a/onprc_billing/build.gradle
+++ b/onprc_billing/build.gradle
@@ -4,4 +4,8 @@ dependencies {
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:onprc_ehr", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:sla", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/onprc_billing/module.properties
+++ b/onprc_billing/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.onprc_billing.ONPRC_BillingModule
-ModuleDependencies: LDK, EHR, ONPRC_EHR, SLA
 SupportedDatabases : mssql
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/onprc_billingpublic/build.gradle
+++ b/onprc_billingpublic/build.gradle
@@ -1,0 +1,6 @@
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:onprc_ehr", depProjectConfig: "published", depExtension: "module")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:onprc_billing", depProjectConfig: "published", depExtension: "module")

--- a/onprc_billingpublic/module.properties
+++ b/onprc_billingpublic/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.onprc_billingpublic.ONPRC_BillingPublicModule
-ModuleDependencies: LDK, EHR, ONPRC_EHR, ONPRC_Billing
 SupportedDatabases : mssql
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/onprc_ehr/build.gradle
+++ b/onprc_ehr/build.gradle
@@ -5,4 +5,7 @@ dependencies
    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:mergesync", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/onprc_ehr/module.properties
+++ b/onprc_ehr/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.onprc_ehr.ONPRC_EHRModule
-ModuleDependencies: LDK, EHR, MergeSync
 SupportedDatabases: mssql
 ManageVersion: false

--- a/onprc_reports/build.gradle
+++ b/onprc_reports/build.gradle
@@ -3,4 +3,8 @@ import org.labkey.gradle.util.BuildUtils;
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:GeneticsCore", depProjectConfig: "published", depExtension: "module")
 }

--- a/onprc_reports/module.properties
+++ b/onprc_reports/module.properties
@@ -1,3 +1,2 @@
 ModuleClass: org.labkey.onprc_reports.ONPRC_ReportsModule
-ModuleDependencies: LDK, EHR, GeneticsCore
 ManageVersion: false

--- a/onprc_ssu/build.gradle
+++ b/onprc_ssu/build.gradle
@@ -1,6 +1,10 @@
-import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.BuildUtils
 
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:onprc_ehr", depProjectConfig: "published", depExtension: "module")
 }

--- a/onprc_ssu/module.properties
+++ b/onprc_ssu/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.onprc_ssu.ONPRC_SSUModule
-ModuleDependencies: LDK, EHR, ONPRC_EHR
 SupportedDatabases : mssql
 ManageVersion: false

--- a/sla/build.gradle
+++ b/sla/build.gradle
@@ -4,4 +4,7 @@ dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
 }

--- a/sla/module.properties
+++ b/sla/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.sla.SLAModule
 SupportedDatabases: mssql
-ModuleDependencies: LDK, EHR
 ManageVersion: false

--- a/treatmentETL/build.gradle
+++ b/treatmentETL/build.gradle
@@ -1,0 +1,4 @@
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")

--- a/treatmentETL/module.properties
+++ b/treatmentETL/module.properties
@@ -1,5 +1,4 @@
 Name: TreatmentETL
 ModuleClass: org.labkey.api.module.SimpleModule
-ModuleDependencies: DataIntegration,Study
 RequiredServerVersion: 15.2
 ManageVersion: false


### PR DESCRIPTION
#### Rationale
If a module takes a dependency on another module's jar file, we want to also declare a dependency on the module file so when not building everything from source we'll bring in the requisite modules and their jar files to the distribution.  Only in the rare case where we depend on an API jar and also check for the existence of corresponding module will we not also include the module dependency, and in that case we would declare the dependency on the jar file using the `labkey` configuration so the jar file will get copied to the `lib` directory of the module declaring the dependency and thus be available without the module.

We have also deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add missing module dependencies
* Move module dependency declarations from `module.properties` files to `build.gradle` files