### PR TITLE
Use core.fn_dropifexists to drop db objects to keep it backward compatible with MS SQL Server 2012

### DIFF
--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.502-20.503.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.502-20.503.sql
@@ -4,8 +4,9 @@ Created by jonesga
 Purpose:  Dataset to mimic DateRange from Labkey for SCheduler actionin SQL
 
 */
-DROP TABLE IF EXISTS extScheduler.DateParts
+EXEC core.fn_dropifexists 'DateParts','extScheduler','TABLE';
 GO
+
 CREATE TABLE extScheduler.dateParts
 (date datetime,
 dateOnly datetime,

--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.503-20.504.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.503-20.504.sql
@@ -14,9 +14,9 @@
 -- Create date: 2020-05-13
 -- Description:	PRocedure to Block out Scheduling for Covid19 testing for  3:30 to 7 PM on Monday and Friday
 -- =============================================
-
-DROP PROCEDURE IF EXISTS extscheduler.extBlockOutEvening
+EXEC core.fn_dropifexists 'extBlockOutEvening', 'extscheduler', 'PROCEDURE'
 GO
+
 CREATE PROCEDURE extscheduler.extBlockOutEvening
     -- Add the parameters for the stored procedure here
     @Month INTEGER, @ResourceID INTEGER

--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.504-20.505.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.504-20.505.sql
@@ -15,7 +15,7 @@
 -- Create date: 2020-05-13
 -- Description:	PRocedure to Block out Scheduling for Covid19 testing for  7 to 8 on Monday and Friday
 -- =============================================
-DROP PROCEDURE IF EXISTS [extscheduler].[extBlockOutMorning]
+EXEC core.fn_dropifexists 'extBlockOutMorning', 'extscheduler', 'PROCEDURE'
 GO
 
 CREATE PROCEDURE [extscheduler].[extBlockOutMorning]

--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.505-20.506.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.505-20.506.sql
@@ -15,7 +15,7 @@
 -- Create date: 2020-05-13
 -- Description:	PRocedure to Block out Scheduling for Covid19 testing for all days except Monday and Friday
 -- =============================================
-DROP PROCEDURE IF EXISTS [extscheduler].[extBlockOutDays]
+EXEC core.fn_dropifexists 'extBlockOutDays', 'extscheduler', 'PROCEDURE'
 GO
 
 CREATE PROCEDURE [extscheduler].[extBlockOutDays]

--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.601-20.602.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.601-20.602.sql
@@ -16,9 +16,7 @@
  * Created by jonesga
  * Purpose -  View joining Scheduler Resources, Events and the User Data
  */
-
-
-DROP VIEW IF EXISTS extScheduler.vw_Covid19Research
+EXEC core.fn_dropifexists 'vw_Covid19Research', 'extScheduler', 'VIEW', NULL;
 GO
 
 CREATE VIEW extScheduler.vw_Covid19Research AS

--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.602-20.603.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.602-20.603.sql
@@ -16,8 +16,7 @@
  * Created by jonesga
  * Purpose -  View joining Scheduler Resources, Events and the User Data
  */
-
-DROP VIEW IF EXISTS extScheduler.vw_Covid19DCMSchedule
+EXEC core.fn_dropifexists 'vw_Covid19DCMSchedule', 'extScheduler', 'VIEW', NULL;
 GO
 
 CREATE VIEW extScheduler.vw_Covid19DCMSchedule AS

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.101-20.102.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.101-20.102.sql
@@ -1,13 +1,18 @@
 -- Adds change inflation rate to 3 position decimal
 -- add primary key and identity key
 --If the field exists in the current build we drop the column and recreate
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [COMMENTS];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'COMMENTS';
+GO
 ALTER TABLE onprc_billing.aliases ADD [COMMENTS] VarChar(255) Null;
 
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [dateDisabled];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'dateDisabled';
+GO
 ALTER TABLE onprc_billing.aliases ADD [dateDisabled] DATETIME Null;
 
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [PPQNumber];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'PPQNumber';
+GO
 ALTER TABLE onprc_billing.aliases ADD [PPQNumber] VARCHAR(25) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [PPQDate];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'PPQDate';
+GO
 ALTER TABLE onprc_billing.aliases ADD [PPQDate] DATETIME Null;

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.102-20.103.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.102-20.103.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS onprc_billing.ogaSynch
+EXEC core.fn_dropifexists 'ogaSynch','onprc_billing','TABLE';
 GO
 
 CREATE TABLE [onprc_billing].[ogasynch](

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.104-20.105.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.104-20.105.sql
@@ -1,39 +1,68 @@
 -- Adding additional Fields for Alias insert from OGA Synch
 --Rerunning and it does not appear in Build
 --2020-03-4 Revision to add this to UAT
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ApplicationType];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ApplicationType';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ApplicationType] VarChar(255) Null;
 
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ApplicationTypeDescription];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ApplicationTypeDescription';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ApplicationTypeDescription]  VarChar(255) Null;
 
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardStatus];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardStatus';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardStatus] VARCHAR(100) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardID];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardID';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardID] VARCHAR(100) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ApplicationType];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ApplicationType';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ApplicationType] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ProjectID];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ProjectID';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ProjectID] VARCHAR(100) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ActivityType];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ActivityType';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ActivityType] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardNumber];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardNumber';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardNumber] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardSuffix];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardSuffix';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardSuffix] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [Org];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'Org';
+GO
 ALTER TABLE onprc_billing.aliases ADD [Org] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ADFMEmpNum];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ADFMEmpNum';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ADFMEmpNum] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ADFMFullName];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ADFMFullName';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ADFMFullName] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ActivityTypeDescription];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ActivityTypeDescription';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ActivityTypeDescription] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [FundingSourceNumber];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'FundingSourceNumber';
+GO
 ALTER TABLE onprc_billing.aliases ADD [FUndingSourceNumber] VARCHAR(255) NUll
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [FundingSourceName];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'FundingSourceName';
+GO
 ALTER TABLE onprc_billing.aliases ADD [FUndingSourceName] VARCHAR(255) NUll
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [Org];
+
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'Org';
+GO
 ALTER TABLE onprc_billing.aliases ADD [Org] VARCHAR(255) NUll
 
 --Adding additional fields to OGA Synch

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.508-20.509.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.508-20.509.sql
@@ -1,39 +1,55 @@
 -- Adding additional Fields for Alias insert from OGA Synch
 --Rerunning and it does not appear in Build
 --2020-03-4 Revision to add this to UAT
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ApplicationType];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ApplicationType';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ApplicationType] VarChar(255) Null;
 
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ApplicationTypeDescription];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ApplicationTypeDescription';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ApplicationTypeDescription]  VarChar(255) Null;
 
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardStatus];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardStatus';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardStatus] VARCHAR(100) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardID];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardID';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardID] VARCHAR(100) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ApplicationType];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ApplicationType';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ApplicationType] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ProjectID];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ProjectID';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ProjectID] VARCHAR(100) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ActivityType];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ActivityType';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ActivityType] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardNumber];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardNumber';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardNumber] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [AwardSuffix];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'AwardSuffix';
+GO
 ALTER TABLE onprc_billing.aliases ADD [AwardSuffix] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [Org];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'Org';
+GO
 ALTER TABLE onprc_billing.aliases ADD [Org] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ADFMEmpNum];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ADFMEmpNum';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ADFMEmpNum] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ADFMFullName];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ADFMFullName';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ADFMFullName] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [ActivityTypeDescription];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'ActivityTypeDescription';
+GO
 ALTER TABLE onprc_billing.aliases ADD [ActivityTypeDescription] VARCHAR(255) NUll;
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [FundingSourceNumber];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'FundingSourceNumber';
+GO
 ALTER TABLE onprc_billing.aliases ADD [FUndingSourceNumber] VARCHAR(255) NUll
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [FundingSourceName];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'FundingSourceName';
+GO
 ALTER TABLE onprc_billing.aliases ADD [FUndingSourceName] VARCHAR(255) NUll
-ALTER TABLE onprc_billing.aliases DROP COLUMN IF EXISTS [Org];
+EXEC core.fn_dropifexists 'aliases', 'onprc_billing', 'COLUMN', 'Org';
+GO
 ALTER TABLE onprc_billing.aliases ADD [Org] VARCHAR(255) NUll
 
 --Adding additional fields to OGA Synch

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.511-20.512.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.511-20.512.sql
@@ -5,8 +5,9 @@
   Purpose:  Resets the Alias Dataset for Insert from OGA, Keeping GL Accounts
 
   Script Date: 5/18/2020 10:33:15 AM ******/
-DROP PROCEDURE IF EXISTS [onprc_billing].[OGA_RemoveRecords]
+EXEC core.fn_dropifexists 'OGA_RemoveRecords', 'onprc_billing', 'PROCEDURE'
 GO
+
 CREATE PROCEDURE [onprc_billing].[OGA_RemoveRecords]
     AS
     BEGIN

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.512-20.513.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.512-20.513.sql
@@ -1,6 +1,6 @@
 
 /****** Object:  StoredProcedure [onprc_billing].[oga_InsertRecords]    Script Date: 5/18/2020 10:35:50 AM ******/
-DROP PROCEDURE IF EXISTS [onprc_billing].[oga_InsertRecords]
+EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
 GO
 
 CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.411-20.412.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.411-20.412.sql
@@ -2,16 +2,14 @@
 /****** Object:  Table [onprc_ehr].[PotentialDam_source]    Script Date: 4/121/20202 7:00:04 AM ******/
 /****** Object:  Table [onprc_ehr].[PotentialParents_source]    Script Date: 4/121/20202 7:00:04 AM ******/
 
-DROP TABLE IF EXISTS [onprc_ehr].[potentialDam_Source]
+EXEC core.fn_dropifexists 'potentialDam_Source','onprc_ehr','TABLE';
 GO
 
-DROP TABLE IF EXISTS [onprc_ehr].[potentialsire_Source]
+EXEC core.fn_dropifexists 'potentialsire_Source','onprc_ehr','TABLE';
 GO
 
-DROP TABLE IF EXISTS [onprc_ehr].[potentialParents_Source]
+EXEC core.fn_dropifexists 'potentialParents_Source','onprc_ehr','TABLE';
 GO
-
-
 
 /****** Object:  Table [onprc_ehr].[PotentialSire_source]    Script Date: 4/121/20202 7:00:04 AM ******/
 CREATE TABLE [onprc_ehr].[PotentialSire_source](

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.416-20.417.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.416-20.417.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS [onprc_ehr].[StudyDetails_Reference_Data]
+EXEC core.fn_dropifexists 'StudyDetails_Reference_Data','onprc_ehr','TABLE';
 GO
 
 /****** Object:  Table [onprc_ehr].[StudyDetails_Reference_Data]    Script Date: 2/20/2020 ******/


### PR DESCRIPTION
#### Rationale
Use of DROP IF EXISTS causes Teamcity failures for the tests that run with sql server 2012

#### Changes
Use core.fn_dropifexists to drop tables, columns, views, and procedures