### PR TITLE
Fixed typo in column name.

### DIFF
--- a/onprc_billing/resources/queries/onprc_billing/aliases/.qview.xml
+++ b/onprc_billing/resources/queries/onprc_billing/aliases/.qview.xml
@@ -25,7 +25,7 @@
         <column name="AwardStatus"/>
         <column name="Org"/>
         <column name="budgetEndDateCoalesced"/>
-        <column name="budhetEndDatetimeCoalesced"/>
+        <column name="budgetEndDatetimeCoalesced"/>
     </columns>
     <sorts>
         <sort column="alias"/>


### PR DESCRIPTION
Needed to correct a typo on a column name.