### PR TITLE
Add build.gradle file in anticipation of removal of modules/build.gradle

### DIFF
--- a/GeneticsCore/build.gradle
+++ b/GeneticsCore/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')

--- a/HormoneAssay/build.gradle
+++ b/HormoneAssay/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")

--- a/ONPRC_EHR_ComplianceDB/build.gradle
+++ b/ONPRC_EHR_ComplianceDB/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.fileModule'
+}

--- a/extscheduler/build.gradle
+++ b/extscheduler/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')

--- a/mergesync/build.gradle
+++ b/mergesync/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")

--- a/ogasync/build.gradle
+++ b/ogasync/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 

--- a/onprc_billing/build.gradle
+++ b/onprc_billing/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")

--- a/onprc_billingpublic/build.gradle
+++ b/onprc_billingpublic/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:onprcEHRModules:onprc_ehr", depProjectConfig: "published", depExtension: "module")

--- a/onprc_ehr/build.gradle
+++ b/onprc_ehr/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies
 {
    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"

--- a/onprc_reports/build.gradle
+++ b/onprc_reports/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")

--- a/onprc_ssu/build.gradle
+++ b/onprc_ssu/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")

--- a/sla/build.gradle
+++ b/sla/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")

--- a/treatmentETL/build.gradle
+++ b/treatmentETL/build.gradle
@@ -1,4 +1,8 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
 BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  

#### Changes
* apply module plugin in build.gradle file