### PR TITLE
Address onprc script warnings

### DIFF
--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.504-20.505.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.504-20.505.sql
@@ -50,6 +50,6 @@ BEGIN
     where c.dayofWeek in (2,6) and c.Month = @Month
 --Days of Week start with Sunday
 
-
-
 END
+
+GO

--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.505-20.506.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.505-20.506.sql
@@ -50,6 +50,6 @@ BEGIN
     where c.dayofWeek in (1,3,4,5,7) and c.Month = @Month
 --Days of Week start with Sunday
 
-
-
 END
+
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-12.372-18.10.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-12.372-18.10.sql
@@ -341,3 +341,5 @@ from  Rpt_ChargesProjection
 Order by  chargeid
 
 END
+
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.511-20.512.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.511-20.512.sql
@@ -18,3 +18,5 @@ CREATE PROCEDURE [onprc_billing].[OGA_RemoveRecords]
 
 
     END
+
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.512-20.513.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.512-20.513.sql
@@ -80,4 +80,4 @@ CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
         From [onprc_billing].[ogasynch]
     END
 
-
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.514-20.515.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.514-20.515.sql
@@ -97,4 +97,4 @@ ALTER PROCEDURE [onprc_billing].[oga_InsertRecords]
 
     END
 
-
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.515-20.516.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.515-20.516.sql
@@ -123,3 +123,5 @@ Select @unitCostVal =
            return @unitCostVal--@projectExemption
 
 End
+
+GO

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.412-20.413.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.412-20.413.sql
@@ -63,9 +63,6 @@
         WHERE d.gender = 'm' and DateDiff(day, d.birth, b.date) > 912.5 --(2.5 years)
           AND d.species = d1.species
 
-
-
-
-
-
     END
+
+GO

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.413-20.414.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.413-20.414.sql
@@ -62,9 +62,6 @@ CREATE PROCEDURE [onprc_ehr].[PotentialSire_Insert]
         WHERE d.gender = 'm' and DateDiff(day, d.birth, b.date) > 912.5 --(2.5 years)
           AND d.species = d1.species
 
-
-
-
-
-
     END
+
+GO

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.415-20.416.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.415-20.416.sql
@@ -66,9 +66,6 @@
         WHERE d.gender = 'f' and DateDiff(day, d.birth, b.date) > 912.5 --(2.5 years)
           AND d.species = d1.species
 
-
-
-
-
-
     END
+
+GO


### PR DESCRIPTION
#### Rationale
10 ONPRC SQL scripts are being flagged with warnings because they don't end with a GO statement. This will cause problems if any of the scripts is consolidated or combined in the future. Best to address the warnings now.