### PR TITLE
20.11 fb ext scheduler update

### DIFF
--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.910-20.911.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.910-20.911.sql
@@ -1,6 +1,7 @@
 EXEC core.fn_dropifexists 'TempScheduler', 'extScheduler', 'TABLE', NULL;
 GO
-
+DROP TABLE IF EXISTS [extScheduler].[TempScheduler]
+GO
 CREATE TABLE [extscheduler].[TempScheduler](
     [Searchkey] [int] IDENTITY(100,1) NOT NULL,
     [usernames] [varchar](500) NULL,

--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.911-20.912.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.911-20.912.sql
@@ -1,9 +1,13 @@
 EXEC core.fn_dropifexists 'TempCoV19Interim', 'extScheduler', 'TABLE', NULL;
 GO
 
+
 /****** Object:  Table [extscheduler].[TempScheduler]
   ONCE TESTED CHAN GE TO labkey_public
   Script Date: 10/29/2020 8:19:18 AM ******/
+DROP TABLE IF EXISTS [extscheduler].[TempCoV19Interim];
+GO;
+
 
 CREATE TABLE [extscheduler].[TempCoV19Interim](
     [EventId] [varchar](max) NULL,

--- a/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
@@ -2541,7 +2541,7 @@ public class ONPRC_EHRTriggerHelper
         if (id == null || date == null || quantity == null)
             return null;
 
-        //Get ABV data from onprc_ehr.AvailableBloodVolume
+        //Get ABV data from onprc_ehr.AvailableBloodVolumeA
         Double maxAllowable = getABV(id);
         if (maxAllowable == null)
             return "Couldn't find available blood volume for AnimalId: " + id ;


### PR DESCRIPTION
#### Rationale
The existing merge attempted to create tables that already existed and the sql string should have included a drop if exists statement

#### Related Pull Requests
Issue was found with last merge relating to extscheduler files

#### Changes
Changed each script to insure it included a drop if exists statement
