### PR TITLE
Ticket 42248: drop manually added Covid19Testing before creating it

### DIFF
--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.901-20.902.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.901-20.902.sql
@@ -1,5 +1,7 @@
 
 /****** Object:  Table [list].[c10437d746_covid19testing]    Script Date: 9/16/2020 9:19:28 AM ******/
+EXEC core.fn_dropifexists 'Covid19Testing', 'extScheduler', 'TABLE', NULL;
+GO
 
 CREATE TABLE [extScheduler].[Covid19Testing](
     [container] [dbo].[ENTITYID] NOT NULL,


### PR DESCRIPTION
#### Rationale
Existing DBs may have the extscheduler.Covid19Testing table from manual manipulation, or a since-edited upgrade script.

#### Changes
* Drop any existing table in a SQL Server 2012 compatible way before creating the new variant