### PR TITLE
Ticket 42312: Missing submenu selection from Research Procedure entry from

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/AuxProcedureFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/AuxProcedureFormType.java
@@ -64,6 +64,10 @@ public class AuxProcedureFormType extends TaskForm
 
         addClientDependency(ClientDependency.supplierFromPath("ehr/model/sources/ResearchProcedures.js"));
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/BulkBloodDrawWindow.js"));
+
+        //        Added 12-20-2017  R.Blasa
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/CopyTaskWindow.js"));
+
         setDisplayReviewRequired(true);
     }
     //Added 2-24-2016  Blasa


### PR DESCRIPTION
#### Rationale
Restore the missing "Copy previous task" menu item, which didn't get fully merged to the 20.11 branch

#### Changes
* Add dependency on ONPRC's CopyTaskWindow.js