### PR TITLE
Fix SQL Server 2012 testing on TeamCity - remove redundant DROP IF EXISTS

### DIFF
--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.903-20.904.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-20.903-20.904.sql
@@ -3,9 +3,6 @@
 EXEC core.fn_dropifexists 'Covid19Testing', 'extScheduler', 'TABLE', NULL;
 GO
 
-
-DROP TABLE IF EXISTS [extScheduler].[Covid19Testing]
-GO
 CREATE TABLE [extScheduler].[Covid19Testing](
     [container] [dbo].[ENTITYID] NOT NULL,
     [entityId] [dbo].[ENTITYID] NOT NULL,

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.910-20.911.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.910-20.911.sql
@@ -1,6 +1,7 @@
 /****** Object:  StoredProcedure [onprc_billing].[OGA_RemoveRecords]    Script Date: 10/15/2020 9:30:00 AM ******/
-DROP PROCEDURE IF EXISTS [onprc_billing].[ClearOGASync]
-    GO
+
+EXEC core.fn_dropifexists 'ClearOGASync', 'onprc_billing', 'PROCEDURE'
+GO
 
 CREATE PROCEDURE [onprc_billing].[ClearOGASync]
 AS

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.911-20.912.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.911-20.912.sql
@@ -3,7 +3,7 @@
   Script Date: 5/18/2020 10:35:50 AM
 Update 2020-11-25 jonesga to change source of fa rate from burden rate to cast value
   ******/
-DROP PROCEDURE IF EXISTS [onprc_billing].[oga_InsertRecords]
+EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
 GO
 
 CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.912-20.913.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.912-20.913.sql
@@ -3,7 +3,7 @@
   Script Date: 5/18/2020 10:35:50 AM
 Update 2020-11-25 jonesga to change source of fa rate from burden rate to cast value
   ******/
-DROP PROCEDURE IF EXISTS [onprc_billing].[oga_InsertRecords]
+EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
 GO
 
 CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.913-20.914.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.913-20.914.sql
@@ -1,6 +1,7 @@
 /****** Object:  StoredProcedure [onprc_billing].[oga_InsertRecords]    Script Date: 12/2/2020 12:18:09 PM ******/
-DROP PROCEDURE IF EXISTS [onprc_billing].[oga_InsertRecords]
-    GO
+EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
+GO
+
 CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
 
 

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.914-20.915.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.914-20.915.sql
@@ -1,5 +1,6 @@
-DROP PROCEDURE IF EXISTS [onprc_billing].[oga_InsertRecords]
-    GO
+EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
+GO
+
 CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
 
 

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.916-20.917.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.916-20.917.sql
@@ -1,5 +1,6 @@
-DROP PROCEDURE IF EXISTS [onprc_billing].[oga_InsertRecords]
-    GO
+EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
+GO
+
 CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
 
 

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.917-20.918.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.917-20.918.sql
@@ -1,5 +1,6 @@
-DROP PROCEDURE IF EXISTS [onprc_billing].[oga_InsertRecords]
-    GO
+EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
+GO
+
 CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
 
 


### PR DESCRIPTION
#### Rationale
TeamCity runs tests on SQL Server 2012 since we officially support it, and this script is using a syntax that's not supported
 
#### Changes
* Remove redundant DROP IF EXISTS, as previous statement has already used the 2012-compatible stored procedure to drop it