### PR TITLE
Added correct set of ONPRC dependency file

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
@@ -91,8 +91,10 @@ public class ClinicalReportFormType extends TaskForm
         setStoreCollectionClass("EHR.data.ClinicalReportStoreCollection");
         addClientDependency(ClientDependency.supplierFromPath("ehr/data/ClinicalReportStoreCollection.js"));
         addClientDependency(ClientDependency.supplierFromPath("ehr/model/sources/ClinicalDefaults.js"));
-        addClientDependency(ClientDependency.supplierFromPath("ehr/model/sources/ClinicalReport.js"));
         addClientDependency(ClientDependency.supplierFromPath("ehr/model/sources/ClinicalReportChild.js"));
+
+        //  Modified: 10-5-2017  R.Blasa  reinstalled 2-12-21
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/model/sources/ClinicalReport.js"));
 
         //Added 4-3-2015 Blasa
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/panel/HousingDataEntryPanel.js"));


### PR DESCRIPTION
#### Rationale
The original code from 19.1 was not included into this version of 20.11 file.

#### Related Pull Requests


#### Changes
Provided a correct set of codes that populates all other input screens with a specific date entered from main soap input screen.
