### PR TITLE
Modified program files to include code that was left out

### DIFF
--- a/onprc_billing/src/org/labkey/onprc_billing/dataentry/ChargesFormSection.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/dataentry/ChargesFormSection.java
@@ -42,10 +42,14 @@ public class ChargesFormSection extends SimpleFormSection
         setConfigSources(Collections.singletonList("Task"));
         setClientStoreClass("EHR.data.MiscChargesClientStore");
         addClientDependency(ClientDependency.supplierFromPath("ehr/data/MiscChargesClientStore.js"));
-        addClientDependency(ClientDependency.supplierFromPath("ehr/data/MiscChargesClientStore.js"));
+
 
         //            Added: 1-19-2018 R.Blasa
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/AddAnimalsWindow.js"));
+
+        //            Added: 6-8-2017  R.Blasa
+        addClientDependency(ClientDependency.supplierFromPath("onprc_billing/model/sources/AliasMisc.js"));
+        addConfigSource("AliasMisc");
 
     }
     //            Added: 3-8-2018 R.Blasa


### PR DESCRIPTION
from version 19.1 into 20.11.  Alias column was missing.

#### Rationale


#### Related Pull Requests


#### Changes
Alias column missing from Charges entry screen.  Code was on 19.1 version, but missing on 20.11
