### PR TITLE
Workaround for TreatmentToDrug ETL ObjectId value in the target

### DIFF
--- a/onprc_ehr/resources/etls/TreatmentToDrug.xml
+++ b/onprc_ehr/resources/etls/TreatmentToDrug.xml
@@ -5,7 +5,7 @@
     <transforms>
         <transform id="step1">
             <description>Transfer to Drug Table</description>
-            <source queryName="treatmentToDrug" schemaName="study"/>
+            <source queryName="TreatmentToDrug" schemaName="study"/>
             <destination schemaName="study" queryName="Drug"/>
         </transform>
     </transforms>

--- a/treatmentETL/resources/queries/study/treatmenttodrug.sql
+++ b/treatmentETL/resources/queries/study/treatmenttodrug.sql
@@ -2,7 +2,6 @@ SELECT t.id,
 t.calculated_status,
 t.lsid,
 t.dataset,
-t.animalid,
 t.time,
 t.hours,
 t.minutes,
@@ -37,7 +36,7 @@ t.qcstate,
 t.date,
 t.timeOfDay,
 t.timeOffset,
-t.treatmentid,
+t.treatmentid || '' AS TreatmentId,
 t.treatmentStatus
 FROM treatmentScheduleUpdate t left outer join Drug d on t.id = d.id and t.code = d.code and t.date = d.date
 where d.id is null and d.date is null and d.code is null


### PR DESCRIPTION
#### Rationale
TreatmentToDrug ETL is failing because it's pulling Treatment Order table's ObjectId value and inserting it into the Drug table. That causes a duplicate key violation when there multiple doses for a single day

#### Changes
* Use SQL expression so that the association with ObjectId is lost
* Rename files to match casing that's already present in ONPRC DB, preventing an error creating the experiment run that's describing the ETL