### PR TITLE
Fire formulary actions when a template is populating the form

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/data/sources/TreatmentOrdersClientStore.js
+++ b/onprc_ehr/resources/web/onprc_ehr/data/sources/TreatmentOrdersClientStore.js
@@ -16,7 +16,7 @@ Ext4.define('ONPRC_EHR.data.TreatmentOrdersClientStore', {
 
     onAddRecord: function(store, records){
         Ext4.each(records, function(record){
-            this.onRecordUpdate(record, ['objectid']);
+            this.onRecordUpdate(record, ['objectid', 'code']);
         }, this);
     },
 


### PR DESCRIPTION
#### Rationale
ONPRC_EHRTest.testExamEntry started failing with recent changes to the formulary code, noticing that the formulary wasn't being applied when a template populated a row

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/86

#### Changes
* When adding a new row make sure the formulary code fires too