### PR TITLE
20.11 fb override bcs weight duration

### DIFF
--- a/ONPRC_EHR_ComplianceDB/resources/queries/EHR_ComplianceDB/Measles45DayAlert.sql
+++ b/ONPRC_EHR_ComplianceDB/resources/queries/EHR_ComplianceDB/Measles45DayAlert.sql
@@ -1,47 +1,48 @@
+--update kollil 2021-02-04
+
 SELECT
-	emp.employeeid,
-	emp.Name,
-	emp.email,
-	emp.unit,
-	emp.category,
-	emp.location,
-	emp.majorudds,
-	emp.notes,
-	emp.requirementname,
-	--c.date,
-	Case
-       When (c.requirementname is null) Then emp.date
-       When (c.requirementname is not null) Then c.date
-       ELSE ''
-	End AS DateCompleted,
-	emp.comment,
-	emp.trainer,
-	Case
-       When (c.requirementname is null) Then TIMESTAMPDIFF('SQL_TSI_DAY', emp.date, now())
-       When (c.requirementname is not null) Then '-1'
-       ELSE ''
-	End as DaysOverDue
-	FROM ehr_compliancedb.completiondates c
-	RIGHT JOIN (
-       SELECT
-       c1.employeeid,
-       emp.email,
-       emp.Firstname + ' ' + emp.Lastname as Name,
-       emp.unit,
-       emp.category,
-       emp.location,
-       emp.majorudds,
-       emp.notes,
-       emp.isActive,
-       c1.requirementname,
-       c1.date,
-       c1.result,
-       c1.comment,
-       c1.trainer
-       FROM ehr_compliancedb.completiondates c1, ehr_compliancedb.employees emp
-       Where c1.employeeid = emp.employeeid
-       And c1.requirementname like 'Occupational Health - Measles Compliant - Initial'
-       And emp.endDate is null
-       ) emp
-	ON c.employeeid = emp.employeeid
-	And c.requirementname like 'Occupational Health - Measles Compliant'
+    emp.employeeid,
+    emp.Name,
+    emp.email,
+    emp.unit,
+    emp.category,
+    emp.location,
+    emp.majorudds,
+    emp.notes,
+    emp.requirementname,
+    --c.date,
+    Case
+        When (c.requirementname is null) Then emp.date
+        When (c.requirementname is not null) Then c.date
+        ELSE ''
+        End AS DateCompleted,
+    emp.comment,
+    emp.trainer,
+    Case
+        When (c.requirementname is null) Then TIMESTAMPDIFF('SQL_TSI_DAY', emp.date, now())
+        When (c.requirementname is not null) Then -1
+        End As DaysOverDue
+FROM ehr_compliancedb.completiondates c
+         RIGHT JOIN (
+    SELECT
+        c1.employeeid,
+        emp.email,
+        emp.Firstname + ' ' + emp.Lastname as Name,
+        emp.unit,
+        emp.category,
+        emp.location,
+        emp.majorudds,
+        emp.notes,
+        emp.isActive,
+        c1.requirementname,
+        c1.date,
+        c1.result,
+        c1.comment,
+        c1.trainer
+    FROM ehr_compliancedb.completiondates c1, ehr_compliancedb.employees emp
+    Where c1.employeeid = emp.employeeid
+      And c1.requirementname like 'Occupational Health - Measles Compliant - Initial'
+      And emp.endDate is null
+) emp
+                    ON c.employeeid = emp.employeeid
+                        And c.requirementname like 'Occupational Health - Measles Compliant'

--- a/ONPRC_EHR_ComplianceDB/resources/queries/EHR_ComplianceDB/Measles45DayAlert.sql
+++ b/ONPRC_EHR_ComplianceDB/resources/queries/EHR_ComplianceDB/Measles45DayAlert.sql
@@ -1,48 +1,47 @@
---update kollil 2021-02-04
-
 SELECT
-    emp.employeeid,
-    emp.Name,
-    emp.email,
-    emp.unit,
-    emp.category,
-    emp.location,
-    emp.majorudds,
-    emp.notes,
-    emp.requirementname,
-    --c.date,
-    Case
-        When (c.requirementname is null) Then emp.date
-        When (c.requirementname is not null) Then c.date
-        ELSE ''
-        End AS DateCompleted,
-    emp.comment,
-    emp.trainer,
-    Case
-        When (c.requirementname is null) Then TIMESTAMPDIFF('SQL_TSI_DAY', emp.date, now())
-        When (c.requirementname is not null) Then -1
-        End As DaysOverDue
-FROM ehr_compliancedb.completiondates c
-         RIGHT JOIN (
-    SELECT
-        c1.employeeid,
-        emp.email,
-        emp.Firstname + ' ' + emp.Lastname as Name,
-        emp.unit,
-        emp.category,
-        emp.location,
-        emp.majorudds,
-        emp.notes,
-        emp.isActive,
-        c1.requirementname,
-        c1.date,
-        c1.result,
-        c1.comment,
-        c1.trainer
-    FROM ehr_compliancedb.completiondates c1, ehr_compliancedb.employees emp
-    Where c1.employeeid = emp.employeeid
-      And c1.requirementname like 'Occupational Health - Measles Compliant - Initial'
-      And emp.endDate is null
-) emp
-                    ON c.employeeid = emp.employeeid
-                        And c.requirementname like 'Occupational Health - Measles Compliant'
+	emp.employeeid,
+	emp.Name,
+	emp.email,
+	emp.unit,
+	emp.category,
+	emp.location,
+	emp.majorudds,
+	emp.notes,
+	emp.requirementname,
+	--c.date,
+	Case
+       When (c.requirementname is null) Then emp.date
+       When (c.requirementname is not null) Then c.date
+       ELSE ''
+	End AS DateCompleted,
+	emp.comment,
+	emp.trainer,
+	Case
+       When (c.requirementname is null) Then TIMESTAMPDIFF('SQL_TSI_DAY', emp.date, now())
+       When (c.requirementname is not null) Then '-1'
+       ELSE ''
+	End as DaysOverDue
+	FROM ehr_compliancedb.completiondates c
+	RIGHT JOIN (
+       SELECT
+       c1.employeeid,
+       emp.email,
+       emp.Firstname + ' ' + emp.Lastname as Name,
+       emp.unit,
+       emp.category,
+       emp.location,
+       emp.majorudds,
+       emp.notes,
+       emp.isActive,
+       c1.requirementname,
+       c1.date,
+       c1.result,
+       c1.comment,
+       c1.trainer
+       FROM ehr_compliancedb.completiondates c1, ehr_compliancedb.employees emp
+       Where c1.employeeid = emp.employeeid
+       And c1.requirementname like 'Occupational Health - Measles Compliant - Initial'
+       And emp.endDate is null
+       ) emp
+	ON c.employeeid = emp.employeeid
+	And c.requirementname like 'Occupational Health - Measles Compliant'

--- a/onprc_ehr/src/org/labkey/onprc_ehr/demographics/BCSScoreWeightsDemographicsProvider.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/demographics/BCSScoreWeightsDemographicsProvider.java
@@ -33,6 +33,15 @@ public class BCSScoreWeightsDemographicsProvider extends AbstractListDemographic
         _supportsQCState = false;
     }
 
+    @Override
+    public Collection<String> getKeysToTest()
+    {
+        Set<String> keys = new HashSet<>(super.getKeysToTest());
+        keys.remove("duration");
+
+        return keys;
+    }
+
     protected Collection<FieldKey> getFieldKeys()
     {
         Set<FieldKey> keys = new HashSet<>();


### PR DESCRIPTION
#### Rationale
THe daily error log was reporting each day that the duration of the BCS weight was changed.  THis is an excepted behavior and should not generate an error

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
CHange to line 36 of BCSScoreWeight demographics
