### PR TITLE
Alias is changed to a required field

### DIFF
--- a/sla/resources/web/sla/form/PurchaseOrderForm.js
+++ b/sla/resources/web/sla/form/PurchaseOrderForm.js
@@ -154,7 +154,8 @@ Ext4.define('SLA.form.PurchaseForm', {
             name: 'account',
             value: this.initData['account'],
             disabled: this.isUpdate && !LABKEY.user.canUpdate,
-            fieldLabel: 'Alias',
+            fieldLabel: 'Alias*',
+            allowBlank: false,
             labelWidth: this.FIELD_LABEL_WIDTH
         });
 


### PR DESCRIPTION
#### Rationale
On SLA purchase order form, the "Alias" field is changed to a required field.

#### Related Pull Requests


#### Changes
Updated the account(Alias) field properties in PurchaseOrderForm.js file
