### PR TITLE
Add initial MHC ETL

### DIFF
--- a/GeneticsCore/resources/etl/MHC_Typing.xml
+++ b/GeneticsCore/resources/etl/MHC_Typing.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>PRIME-seq MHC Data</name>
+    <description>Syncs MHC Typing Data from PRIME-seq</description>
+    <transforms>
+        <transform type="RemoteQueryTransformStep" id="assay">
+            <description>Copy to target</description>
+            <source remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_data_source">
+                <sourceColumns>
+                    <column>Id</column>
+                    <column>allele</column>
+                    <column>shortName</column>
+                    <column>totalTests</column>
+                    <column>result</column>
+                    <column>type</column>
+                </sourceColumns>
+            </source>
+            <destination schemaName="geneticscore" queryName="mhc_data" targetOption="truncate" bulkLoad="true">
+
+            </destination>
+        </transform>
+    </transforms>
+
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" />
+    <schedule>
+        <cron expression="0 20 2 * * ?"/>
+    </schedule>
+</etl>

--- a/GeneticsCore/resources/queries/geneticscore/mhc_data_source.sql
+++ b/GeneticsCore/resources/queries/geneticscore/mhc_data_source.sql
@@ -1,0 +1,41 @@
+SELECT
+  s.subjectId as Id,
+  s.allele,
+  --s.primerPairs,
+  s.shortName,
+  s.totalRecords as testsPerformed,
+  s.status as result,
+  cast('SSP' as varchar) as type
+
+FROM assay.SSP_assay.SSP.SSP_Summary s
+WHERE s.subjectId is not null
+
+UNION ALL
+
+SELECT
+  a.subjectId as Id,
+  a.marker as allele,
+  null as shortName,
+  count(*) as totalTests,
+  cast('POS' as varchar) as result,
+  cast('SBT' as varchar) as type
+
+FROM assay.GenotypeAssay.Genotype.Data a
+WHERE a.run.assayType = 'SBT'
+GROUP BY a.subjectid, a.marker
+
+UNION ALL
+
+SELECT
+  DISTINCT s.subjectId as Id,
+           p.ref_nt_name as allele,
+           null as shortName,
+           1 as totalTests,
+           cast('NEG' as varchar) as result,
+           cast('SBT' as varchar) as type
+
+ --we want any IDs with SBT data, but lacking data for these special-cased markers
+FROM genotypeassays.primer_pairs p
+       FULL JOIN (SELECT DISTINCT subjectId FROM assay.GenotypeAssay.Genotype.Data s WHERE s.run.assayType = 'SBT') s ON (1=1)
+       LEFT JOIN assay.GenotypeAssay.Genotype.Data a ON (a.run.assayType = 'SBT' AND p.ref_nt_name = a.marker AND a.subjectid = s.subjectid)
+WHERE a.rowid IS NULL AND (p.ref_nt_name LIKE 'Mamu-A%' OR p.ref_nt_name LIKE 'Mamu-B%')

--- a/onprc_reports/resources/queries/sequenceanalysis/MHC_Data_Unified.sql
+++ b/onprc_reports/resources/queries/sequenceanalysis/MHC_Data_Unified.sql
@@ -40,17 +40,18 @@ FULL JOIN (SELECT DISTINCT subjectId FROM assay.GenotypeAssay.Genotype.Data s WH
 LEFT JOIN assay.GenotypeAssay.Genotype.Data a ON (a.run.assayType = 'SBT' AND p.ref_nt_name = a.marker AND a.subjectid = s.subjectid)
 WHERE a.rowid IS NULL AND (p.ref_nt_name LIKE 'Mamu-A%' OR p.ref_nt_name LIKE 'Mamu-B%')
 
-UNION ALL
-
-SELECT
-
-  t.subjectId as Id,
-  t.marker as allele,
-  null as shortName,
-  count(*) as totalTests,
-  t.result,
-  GROUP_CONCAT(distinct t.assaytype) as type
-
-FROM geneticscore.mhc_data t
-WHERE t.datatype = 'Lineage'
-GROUP BY t.subjectid, t.marker, t.result
+-- NOTE: eventually this will be the only source of data. However, disable for now so that we can populate this
+-- table on the production server without polluting the results people see.
+-- UNION ALL
+--
+-- SELECT
+--
+--   t.subjectId as Id,
+--   t.marker as allele,
+--   null as shortName,
+--   count(*) as totalTests,
+--   t.result,
+--   GROUP_CONCAT(distinct t.assaytype) as type
+--
+-- FROM geneticscore.mhc_data t
+-- GROUP BY t.subjectid, t.marker, t.result


### PR DESCRIPTION
@jonesgaohsu @labkey-jeckels We discussed migrating all MHC data and associated pipelines from prime to prime-seq, and to make an ETL that will pull aggregated MHC results from prime-seq back to prime. This is the latter. I dont know if I'm targeting the desired branch here, but my hope is that we could merge this into whatever branch PRIMe is running and then deploy to the test server. I need a little more time to get the source data ready, but I think it's worth getting this ETL prepared so that this part is good to go.