### PR TITLE
Disallow null Id values in onprc_ehr.AvailableBloodVolume, give it a PK

### DIFF
--- a/extscheduler/module.properties
+++ b/extscheduler/module.properties
@@ -1,6 +1,5 @@
 Name: extscheduler
 ModuleClass: org.labkey.extscheduler.ExtSchedulerModule
-ModuleDependencies: LDK
 SupportedDatabases: mssql
 RequiredServerVersion: 15.2
 ManageVersion: false

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.905-20.906.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.905-20.906.sql
@@ -1,0 +1,5 @@
+ALTER TABLE onprc_ehr.AvailableBloodVolume ALTER COLUMN Id nvarchar(32) NOT NULL;
+GO
+
+ALTER TABLE onprc_ehr.AvailableBloodVolume ADD CONSTRAINT PK_AvailableBloodVolume PRIMARY KEY (Id);
+GO

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.907-20.908.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-20.907-20.908.sql
@@ -1,0 +1,5 @@
+ALTER TABLE onprc_ehr.AvailableBloodVolume ALTER COLUMN Id nvarchar(32) NOT NULL;
+GO
+
+ALTER TABLE onprc_ehr.AvailableBloodVolume ADD CONSTRAINT PK_AvailableBloodVolume PRIMARY KEY (Id);
+GO

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
@@ -120,7 +120,7 @@ public class ONPRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.905;
+        return 20.906;
     }
 
     @Override

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
@@ -120,7 +120,7 @@ public class ONPRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.907;
+        return 20.908;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
While adding automated test coverage for the ONPRC blood volume validation code, we discovered that having duplicate rows for a given animal in onprc_ehr.AvailableBloodVolume will cause errors when doing the validation. It also lacks a PK, making it hard for the tests to interact with it to populate testing data

#### Changes
* Make the Id column NOT NULL and identify it as the primary key