### PR TITLE
Add GO statements after creating PROCs

### DIFF
--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.910-20.911.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.910-20.911.sql
@@ -9,7 +9,6 @@ BEGIN
 
 Delete from onprc_billing.ogasynch
 
-
-
-
 END
+
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.911-20.912.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.911-20.912.sql
@@ -83,4 +83,4 @@ CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
         From [onprc_billing].[ogasynch]
     END
 
-
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.912-20.913.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.912-20.913.sql
@@ -87,3 +87,4 @@ SELECT
              ,[ORG]
         From [onprc_billing].[ogasynch]
 END
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.913-20.914.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.913-20.914.sql
@@ -88,3 +88,4 @@ SELECT
 		left outer join [onprc_ehr].investigators i on o.[PI EMP NUM] = i.employeeid
 		left outer join onprc_billing.fiscalAuthorities f on f.employeeId = o.[PDFM EMP NUM]
 END
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.914-20.915.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.914-20.915.sql
@@ -1,10 +1,7 @@
 EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
 GO
 
-CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
-
-
-AS
+CREATE PROCEDURE [onprc_billing].[oga_InsertRecords] AS
 BEGIN
 
 INSERT INTO [onprc_billing].[aliases]
@@ -87,3 +84,4 @@ SELECT
 		left outer join [onprc_ehr].investigators i on o.[PI EMP NUM] = i.employeeid
 		left outer join onprc_billing.fiscalAuthorities f on f.employeeId = o.[PDFM EMP NUM]
 END
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.916-20.917.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.916-20.917.sql
@@ -1,10 +1,7 @@
 EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
 GO
 
-CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
-
-
-AS
+CREATE PROCEDURE [onprc_billing].[oga_InsertRecords] AS
 BEGIN
 
 INSERT INTO [onprc_billing].[aliases]
@@ -88,3 +85,4 @@ SELECT
 		left outer join onprc_billing.fiscalAuthorities f on f.employeeId = o.[PDFM EMP NUM] and f.active = 'true';
 
 END
+GO

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.917-20.918.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-20.917-20.918.sql
@@ -1,10 +1,7 @@
 EXEC core.fn_dropifexists 'oga_InsertRecords', 'onprc_billing', 'PROCEDURE'
 GO
 
-CREATE PROCEDURE [onprc_billing].[oga_InsertRecords]
-
-
-AS
+CREATE PROCEDURE [onprc_billing].[oga_InsertRecords] AS
 BEGIN
 
 INSERT INTO [onprc_billing].[aliases]
@@ -88,3 +85,4 @@ SELECT
 		left outer join onprc_billing.fiscalAuthorities f on f.employeeId = o.[PDFM EMP NUM] and f.active = 'true';
 
 END
+GO


### PR DESCRIPTION
#### Rationale
Leaving out the GO statements can lead to problems during future script consolidation