### PR TITLE
Add PMIC and IPC datasets to study archive to fix query validation

### DIFF
--- a/onprc_ehr/resources/referenceStudy/datasets/datasets_manifest.xml
+++ b/onprc_ehr/resources/referenceStudy/datasets/datasets_manifest.xml
@@ -149,5 +149,45 @@
         <dataset name="StudyDetails" id="5039" showByDefault="true" category="Research Procedures" demographicData="false" type="Standard">
             <tags/>
         </dataset>
+        <dataset name="PMIC_PETImagingData" id="5033" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="PMIC_CTImagingData" id="5034" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="PMIC_SPECTImagingData" id="5035" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="PMIC_AngioImagingData" id="5036" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="PMIC_USImagingData" id="5037" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="PMIC_DEXAImagingData" id="5038" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="IPC_Sectioning" id="5040" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="IPC_Staining" id="5041" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="IPC_SlidePrinting" id="5042" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="IPC_Other" id="5043" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="IPC_ServiceRequestDetails" id="5044" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="IPC_CassettePrinting" id="5045" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+        <dataset name="IPC_ProcessingEmbedding" id="5046" showByDefault="false" type="Standard">
+            <tags/>
+        </dataset>
+
     </datasets>
 </datasets>

--- a/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
+++ b/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
@@ -2433,7 +2433,6 @@
                     <fkColumnName>displayName</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="chargeType">
                 <datatype>varchar</datatype>
@@ -2446,28 +2445,24 @@
                     <fkColumnName>chargetype</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="examNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Exam Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="accessionNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Accession Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PMICType">
                 <datatype>varchar</datatype>
                 <columnTitle>PMIC Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PETRadioisotope">
                 <datatype>varchar</datatype>
@@ -2480,7 +2475,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PETDoseMCI">
                 <datatype>double</datatype>
@@ -2507,7 +2501,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="CTDIvol">
                 <datatype>double</datatype>
@@ -2541,7 +2534,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="wetLabUse">
                 <datatype>varchar</datatype>
@@ -2554,35 +2546,30 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="ligandAndComments">
                 <datatype>varchar</datatype>
                 <columnTitle>Ligand and Comments</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="imageUploadLink">
                 <datatype>varchar</datatype>
                 <columnTitle>Image Upload Link</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="CTACType">
                 <datatype>varchar</datatype>
                 <columnTitle>CTACType</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="CTACScanRange">
                 <datatype>varchar</datatype>
                 <columnTitle>CTACScanRange</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>PMIC_PETImagingData</tableTitle>
@@ -2614,7 +2601,6 @@
                     <fkColumnName>displayName</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="chargeType">
                 <datatype>varchar</datatype>
@@ -2627,28 +2613,24 @@
                     <fkColumnName>chargetype</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="examNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Exam Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="accessionNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Accession Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PMICType">
                 <datatype>varchar</datatype>
                 <columnTitle>PMIC Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="contrastType">
                 <datatype>varchar</datatype>
@@ -2661,7 +2643,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="contrastAmount">
                 <datatype>double</datatype>
@@ -2681,7 +2662,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="CTDIvol">
                 <datatype>double</datatype>
@@ -2715,14 +2695,12 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="imageUploadLink">
                 <datatype>varchar</datatype>
                 <columnTitle>Image Upload Link</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>PMIC_CTImagingData</tableTitle>
@@ -2754,7 +2732,6 @@
                     <fkColumnName>displayName</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="chargeType">
                 <datatype>varchar</datatype>
@@ -2767,28 +2744,24 @@
                     <fkColumnName>chargetype</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="examNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Exam Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="accessionNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Accession Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PMICType">
                 <datatype>varchar</datatype>
                 <columnTitle>PMIC Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="SPECTIsotope">
                 <datatype>varchar</datatype>
@@ -2796,7 +2769,6 @@
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <dimension>false</dimension>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="SPECTDoseMCI">
                 <datatype>double</datatype>
@@ -2823,7 +2795,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="CTDIvol">
                 <datatype>double</datatype>
@@ -2857,21 +2828,18 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="ligandAndComments">
                 <datatype>varchar</datatype>
                 <columnTitle>Ligand and Comments</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="imageUploadLink">
                 <datatype>varchar</datatype>
                 <columnTitle>Image Upload Link</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>PMIC_SPECTImagingData</tableTitle>
@@ -2903,7 +2871,6 @@
                     <fkColumnName>displayName</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="chargeType">
                 <datatype>varchar</datatype>
@@ -2916,28 +2883,24 @@
                     <fkColumnName>chargetype</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="examNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Exam Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="accessionNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Accession Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PMICType">
                 <datatype>varchar</datatype>
                 <columnTitle>PMIC Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="CTDIvol">
                 <datatype>double</datatype>
@@ -2971,14 +2934,12 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="imageUploadLink">
                 <datatype>varchar</datatype>
                 <columnTitle>Image Upload Link</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>PMIC_AngioImagingData</tableTitle>
@@ -3010,7 +2971,6 @@
                     <fkColumnName>displayName</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="chargeType">
                 <datatype>varchar</datatype>
@@ -3023,28 +2983,24 @@
                     <fkColumnName>chargetype</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="examNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Exam Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="accessionNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Accession Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PMICType">
                 <datatype>varchar</datatype>
                 <columnTitle>PMIC Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="ultrasoundProcedure">
                 <datatype>varchar</datatype>
@@ -3057,7 +3013,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="wetLabUse">
                 <datatype>varchar</datatype>
@@ -3070,7 +3025,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>PMIC_USImagingData</tableTitle>
@@ -3102,7 +3056,6 @@
                     <fkColumnName>displayName</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="chargeType">
                 <datatype>varchar</datatype>
@@ -3115,28 +3068,24 @@
                     <fkColumnName>chargetype</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="examNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Exam Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="accessionNum">
                 <datatype>varchar</datatype>
                 <columnTitle>Accession Num</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="PMICType">
                 <datatype>varchar</datatype>
                 <columnTitle>PMIC Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="DEXAProcedure">
                 <datatype>varchar</datatype>
@@ -3149,7 +3098,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="animalPosition">
                 <datatype>varchar</datatype>
@@ -3162,7 +3110,6 @@
                     <fkColumnName>value</fkColumnName>
                 </fk>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>PMIC_DEXAImagingData</tableTitle>
@@ -3186,35 +3133,30 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Tissue Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <scale>4000</scale>
             </column>
             <column columnName="paraffinSectioning">
                 <datatype>varchar</datatype>
                 <columnTitle>Paraffin Sectioning</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="sectionThickness">
                 <datatype>varchar</datatype>
                 <columnTitle>SectionThickness</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="frozenSectioning">
                 <datatype>varchar</datatype>
                 <columnTitle>Frozen Sectioning</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="specialIns">
                 <datatype>varchar</datatype>
                 <columnTitle>Special Instructions</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>IPC_Sectioning</tableTitle>
@@ -3238,56 +3180,48 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Tissue Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <scale>4000</scale>
             </column>
             <column columnName="HAndE">
                 <datatype>varchar</datatype>
                 <columnTitle><![CDATA[H&E]]></columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="specialStain">
                 <datatype>varchar</datatype>
                 <columnTitle>Special Stain</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="IHC">
                 <datatype>varchar</datatype>
                 <columnTitle>IHC</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="IHCPrimaryAntibody">
                 <datatype>varchar</datatype>
                 <columnTitle>IHC Primary Antibody</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="irrelevantAntibody">
                 <datatype>varchar</datatype>
                 <columnTitle>Irrevelant Antibody</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="RNAScope">
                 <datatype>varchar</datatype>
                 <columnTitle>RNA Scope</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="other">
                 <datatype>varchar</datatype>
                 <columnTitle>Other</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>IPC_Staining</tableTitle>
@@ -3311,21 +3245,18 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Tissue Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <scale>4000</scale>
             </column>
             <column columnName="projectNotes">
                 <datatype>varchar</datatype>
                 <columnTitle>Project Notes</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="additionalText">
                 <datatype>varchar</datatype>
                 <columnTitle>Additional text on slide</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>IPC_SlidePrinting</tableTitle>
@@ -3349,7 +3280,6 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Service And Products</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>IPC_Other</tableTitle>
@@ -3380,56 +3310,48 @@
                     <fkTable>project</fkTable>
                     <fkColumnName>displayName</fkColumnName>
                 </fk>
-                <scale>4000</scale>
             </column>
             <column columnName="requestedBy">
                 <datatype>varchar</datatype>
                 <columnTitle>Requested By</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="email">
                 <datatype>varchar</datatype>
                 <columnTitle>Email</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="department">
                 <datatype>varchar</datatype>
                 <columnTitle>Department</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="pathologist">
                 <datatype>varchar</datatype>
                 <columnTitle>Pathologist</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="investigator">
                 <datatype>varchar</datatype>
                 <columnTitle>Investigator</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="alias">
                 <datatype>varchar</datatype>
                 <columnTitle>Alias</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="sampleLocation">
                 <datatype>varchar</datatype>
                 <columnTitle>Sample Dropoff/Pickup Location</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>IPC_ServiceRequestDetails</tableTitle>
@@ -3453,14 +3375,12 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Tissue Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <scale>4000</scale>
             </column>
             <column columnName="PILabel">
                 <datatype>varchar</datatype>
                 <columnTitle>PI Label Text</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>IPC_CassettePrinting</tableTitle>
@@ -3484,49 +3404,42 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Tissue Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <scale>4000</scale>
             </column>
             <column columnName="embedding">
                 <datatype>varchar</datatype>
                 <columnTitle>Embedding</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="fixationMethod">
                 <datatype>varchar</datatype>
                 <columnTitle>Fixation Method</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="fixationDuration">
                 <datatype>varchar</datatype>
                 <columnTitle>Fixation Duration</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="currentFixative">
                 <datatype>varchar</datatype>
                 <columnTitle>Current Fixative</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="processingType">
                 <datatype>varchar</datatype>
                 <columnTitle>Processing Type</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
             <column columnName="embeddingIns">
                 <datatype>varchar</datatype>
                 <columnTitle>Embedding Instructions</columnTitle>
                 <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
                 <defaultValueType>FIXED_EDITABLE</defaultValueType>
-                <scale>4000</scale>
             </column>
         </columns>
         <tableTitle>IPC_ProcessingEmbedding</tableTitle>

--- a/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
+++ b/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
@@ -2308,21 +2308,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <nullable>false</nullable>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <nullable>false</nullable>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
             </column>
             <column columnName="tissue">
                 <datatype>varchar</datatype>
@@ -2417,30 +2411,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>AnimalId</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
-            <column columnName="Date">
+            <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Exam Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="project">
                 <datatype>varchar</datatype>
@@ -2613,30 +2592,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>AnimalId</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
-            <column columnName="Date">
+            <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Exam Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="project">
                 <datatype>varchar</datatype>
@@ -2768,30 +2732,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>AnimalId</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
-            <column columnName="Date">
+            <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Exam Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="project">
                 <datatype>varchar</datatype>
@@ -2932,30 +2881,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>AnimalId</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
-            <column columnName="Date">
+            <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Exam Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="project">
                 <datatype>varchar</datatype>
@@ -3054,30 +2988,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>AnimalId</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
-            <column columnName="Date">
+            <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Exam Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="project">
                 <datatype>varchar</datatype>
@@ -3161,30 +3080,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>AnimalId</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
-            <column columnName="Date">
+            <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Exam Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="project">
                 <datatype>varchar</datatype>
@@ -3268,30 +3172,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="tissueType">
                 <datatype>varchar</datatype>
@@ -3335,30 +3224,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="tissueType">
                 <datatype>varchar</datatype>
@@ -3423,30 +3297,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="tissueType">
                 <datatype>varchar</datatype>
@@ -3476,30 +3335,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="serviceAndProducts">
                 <datatype>varchar</datatype>
@@ -3515,30 +3359,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="project">
                 <datatype>varchar</datatype>
@@ -3610,30 +3439,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="tissueType">
                 <datatype>varchar</datatype>
@@ -3656,30 +3470,15 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
-                <columnTitle>Id</columnTitle>
-                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
-                <nullable>false</nullable>
-                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
                 <importAliases>
                     <importAlias>ptid</importAlias>
                 </importAliases>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>Animal</fkTable>
-                    <fkColumnName>Id</fkColumnName>
-                </fk>
-                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
-                <scale>32</scale>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
-                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
                 <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-                <nullable>false</nullable>
-                <formatString>DateTime</formatString>
             </column>
             <column columnName="tissueType">
                 <datatype>varchar</datatype>

--- a/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
+++ b/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
@@ -2328,22 +2328,6 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Organ/Tissue</columnTitle>
             </column>
-            <column columnName="remark">
-                <datatype>varchar</datatype>
-                <inputType>textarea</inputType>
-                <columnTitle>Remark</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Remark</propertyURI>
-            </column>
-            <column columnName="Description">
-                <datatype>varchar</datatype>
-                <inputType>textarea</inputType>
-                <columnTitle>Description</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Description</propertyURI>
-                <isHidden>true</isHidden>
-                <shownInInsertView>false</shownInInsertView>
-                <shownInUpdateView>false</shownInUpdateView>
-                <shownInDetailsView>false</shownInDetailsView>
-            </column>
             <column columnName="objectid">
                 <datatype>entityid</datatype>
                 <columnTitle>Key</columnTitle>
@@ -2353,24 +2337,6 @@
                 <shownInUpdateView>false</shownInUpdateView>
                 <shownInDetailsView>false</shownInDetailsView>
                 <isKeyField>true</isKeyField>
-            </column>
-            <column columnName="parentId">
-                <datatype>varchar</datatype>
-                <columnTitle>Parent Id</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#ParentId</propertyURI>
-                <isHidden>true</isHidden>
-                <shownInInsertView>false</shownInInsertView>
-                <shownInUpdateView>false</shownInUpdateView>
-                <shownInDetailsView>false</shownInDetailsView>
-            </column>
-            <column columnName="taskid">
-                <datatype>varchar</datatype>
-                <columnTitle>Taskid</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#TaskId</propertyURI>
-                <isHidden>true</isHidden>
-                <shownInInsertView>false</shownInInsertView>
-                <shownInUpdateView>false</shownInUpdateView>
-                <shownInDetailsView>false</shownInDetailsView>
             </column>
             <column columnName="project">
                 <datatype>integer</datatype>
@@ -2385,20 +2351,6 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Account</columnTitle>
                 <propertyURI>urn:ehr.labkey.org/#Account</propertyURI>
-            </column>
-            <column columnName="performedby">
-                <datatype>varchar</datatype>
-                <columnTitle>Performed By</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#PerformedBy</propertyURI>
-            </column>
-            <column columnName="requestid">
-                <datatype>varchar</datatype>
-                <columnTitle>Requestid</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#RequestId</propertyURI>
-                <isHidden>true</isHidden>
-                <shownInInsertView>false</shownInInsertView>
-                <shownInUpdateView>false</shownInUpdateView>
-                <shownInDetailsView>false</shownInDetailsView>
             </column>
             <column columnName="enddate">
                 <datatype>timestamp</datatype>
@@ -2458,5 +2410,1326 @@
             </column>
         </columns>
         <tableTitle>StudyDetails</tableTitle>
+    </table>
+
+    <table tableName="PMIC_PETImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_PETImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>AnimalId</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="Date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Exam Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="project">
+                <datatype>varchar</datatype>
+                <columnTitle>Charge To</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>ehr</fkDbSchema>
+                    <fkTable>project</fkTable>
+                    <fkColumnName>displayName</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_ChargeTypes</fkTable>
+                    <fkColumnName>chargetype</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PETRadioisotope">
+                <datatype>varchar</datatype>
+                <columnTitle>PET Radioisotope</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_PETRadioisotope_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PETDoseMCI">
+                <datatype>double</datatype>
+                <columnTitle>PET Dose(mCi)</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="PETDoseMBQ">
+                <datatype>double</datatype>
+                <columnTitle>PET Dose(MBq)</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="route">
+                <datatype>varchar</datatype>
+                <columnTitle>Route</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_Route_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="phantom">
+                <datatype>varchar</datatype>
+                <columnTitle>Phantom</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_Phantom_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_WetLabUse_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="ligandAndComments">
+                <datatype>varchar</datatype>
+                <columnTitle>Ligand and Comments</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="CTACType">
+                <datatype>varchar</datatype>
+                <columnTitle>CTACType</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="CTACScanRange">
+                <datatype>varchar</datatype>
+                <columnTitle>CTACScanRange</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>PMIC_PETImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_CTImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_CTImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>AnimalId</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="Date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Exam Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="project">
+                <datatype>varchar</datatype>
+                <columnTitle>Charge To</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>ehr</fkDbSchema>
+                    <fkTable>project</fkTable>
+                    <fkColumnName>displayName</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_ChargeTypes</fkTable>
+                    <fkColumnName>chargetype</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="contrastType">
+                <datatype>varchar</datatype>
+                <columnTitle>Contrast Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_CTContrastType_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="contrastAmount">
+                <datatype>double</datatype>
+                <columnTitle>Contrast Amount</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="route">
+                <datatype>varchar</datatype>
+                <columnTitle>Route</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_Route_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_WetLabUse_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>PMIC_CTImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_SPECTImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_SPECTImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>AnimalId</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="Date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Exam Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="project">
+                <datatype>varchar</datatype>
+                <columnTitle>Charge To</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>ehr</fkDbSchema>
+                    <fkTable>project</fkTable>
+                    <fkColumnName>displayName</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_ChargeTypes</fkTable>
+                    <fkColumnName>chargetype</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="SPECTIsotope">
+                <datatype>varchar</datatype>
+                <columnTitle>SPECT Isotope</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="SPECTDoseMCI">
+                <datatype>double</datatype>
+                <columnTitle>SPECT Dose(mCi)</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="SPECTDoseMBQ">
+                <datatype>double</datatype>
+                <columnTitle>SPECT Dose(MBq)</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="route">
+                <datatype>varchar</datatype>
+                <columnTitle>Route</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_Route_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.0000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_WetLabUse_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="ligandAndComments">
+                <datatype>varchar</datatype>
+                <columnTitle>Ligand and Comments</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>PMIC_SPECTImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_AngioImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_AngioImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>AnimalId</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="Date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Exam Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="project">
+                <datatype>varchar</datatype>
+                <columnTitle>Charge To</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>ehr</fkDbSchema>
+                    <fkTable>project</fkTable>
+                    <fkColumnName>displayName</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_ChargeTypes</fkTable>
+                    <fkColumnName>chargetype</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
+                <formatString>0.000</formatString>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_WetLabUse_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>PMIC_AngioImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_USImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_USImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>AnimalId</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="Date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Exam Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="project">
+                <datatype>varchar</datatype>
+                <columnTitle>Charge To</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>ehr</fkDbSchema>
+                    <fkTable>project</fkTable>
+                    <fkColumnName>displayName</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_ChargeTypes</fkTable>
+                    <fkColumnName>chargetype</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="ultrasoundProcedure">
+                <datatype>varchar</datatype>
+                <columnTitle>Ultrasound Procedure</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_US_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_WetLabUse_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>PMIC_USImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_DEXAImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_DEXAImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>AnimalId</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="Date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Exam Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="project">
+                <datatype>varchar</datatype>
+                <columnTitle>Charge To</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>ehr</fkDbSchema>
+                    <fkTable>project</fkTable>
+                    <fkColumnName>displayName</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_ChargeTypes</fkTable>
+                    <fkColumnName>chargetype</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="DEXAProcedure">
+                <datatype>varchar</datatype>
+                <columnTitle>DEXA Procedure</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_DEXA_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="animalPosition">
+                <datatype>varchar</datatype>
+                <columnTitle>Animal Position</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>PMIC_DEXA_AnimalPosition_values</fkTable>
+                    <fkColumnName>value</fkColumnName>
+                </fk>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>PMIC_DEXAImagingData</tableTitle>
+    </table>
+    <table tableName="IPC_Sectioning" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_Sectioning data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <scale>4000</scale>
+            </column>
+            <column columnName="paraffinSectioning">
+                <datatype>varchar</datatype>
+                <columnTitle>Paraffin Sectioning</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="sectionThickness">
+                <datatype>varchar</datatype>
+                <columnTitle>SectionThickness</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="frozenSectioning">
+                <datatype>varchar</datatype>
+                <columnTitle>Frozen Sectioning</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="specialIns">
+                <datatype>varchar</datatype>
+                <columnTitle>Special Instructions</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>IPC_Sectioning</tableTitle>
+    </table>
+    <table tableName="IPC_Staining" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_Staining data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <scale>4000</scale>
+            </column>
+            <column columnName="HAndE">
+                <datatype>varchar</datatype>
+                <columnTitle><![CDATA[H&E]]></columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="specialStain">
+                <datatype>varchar</datatype>
+                <columnTitle>Special Stain</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="IHC">
+                <datatype>varchar</datatype>
+                <columnTitle>IHC</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="IHCPrimaryAntibody">
+                <datatype>varchar</datatype>
+                <columnTitle>IHC Primary Antibody</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="irrelevantAntibody">
+                <datatype>varchar</datatype>
+                <columnTitle>Irrevelant Antibody</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="RNAScope">
+                <datatype>varchar</datatype>
+                <columnTitle>RNA Scope</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="other">
+                <datatype>varchar</datatype>
+                <columnTitle>Other</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>IPC_Staining</tableTitle>
+    </table>
+    <table tableName="IPC_SlidePrinting" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_SlidePrinting data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <scale>4000</scale>
+            </column>
+            <column columnName="projectNotes">
+                <datatype>varchar</datatype>
+                <columnTitle>Project Notes</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="additionalText">
+                <datatype>varchar</datatype>
+                <columnTitle>Additional text on slide</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>IPC_SlidePrinting</tableTitle>
+    </table>
+    <table tableName="IPC_Other" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_Other data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="serviceAndProducts">
+                <datatype>varchar</datatype>
+                <columnTitle>Service And Products</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>IPC_Other</tableTitle>
+    </table>
+    <table tableName="IPC_ServiceRequestDetails" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_ServiceRequestDetails data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="project">
+                <datatype>varchar</datatype>
+                <columnTitle>Center Project</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <dimension>false</dimension>
+                <fk>
+                    <fkDbSchema>ehr</fkDbSchema>
+                    <fkTable>project</fkTable>
+                    <fkColumnName>displayName</fkColumnName>
+                </fk>
+                <scale>4000</scale>
+            </column>
+            <column columnName="requestedBy">
+                <datatype>varchar</datatype>
+                <columnTitle>Requested By</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="email">
+                <datatype>varchar</datatype>
+                <columnTitle>Email</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="department">
+                <datatype>varchar</datatype>
+                <columnTitle>Department</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="pathologist">
+                <datatype>varchar</datatype>
+                <columnTitle>Pathologist</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="investigator">
+                <datatype>varchar</datatype>
+                <columnTitle>Investigator</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="alias">
+                <datatype>varchar</datatype>
+                <columnTitle>Alias</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="sampleLocation">
+                <datatype>varchar</datatype>
+                <columnTitle>Sample Dropoff/Pickup Location</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>IPC_ServiceRequestDetails</tableTitle>
+    </table>
+    <table tableName="IPC_CassettePrinting" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_CassettePrinting data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <scale>4000</scale>
+            </column>
+            <column columnName="PILabel">
+                <datatype>varchar</datatype>
+                <columnTitle>PI Label Text</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>IPC_CassettePrinting</tableTitle>
+    </table>
+    <table tableName="IPC_ProcessingEmbedding" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_ProcessingEmbedding data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#ParticipantId</conceptURI>
+                <nullable>false</nullable>
+                <url replaceMissing="blankValue">/ehr/participantView.view?participantId=${id}</url>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
+                <facetingBehavior>ALWAYS_OFF</facetingBehavior>
+                <scale>32</scale>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
+                <formatString>DateTime</formatString>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <scale>4000</scale>
+            </column>
+            <column columnName="embedding">
+                <datatype>varchar</datatype>
+                <columnTitle>Embedding</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="fixationMethod">
+                <datatype>varchar</datatype>
+                <columnTitle>Fixation Method</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="fixationDuration">
+                <datatype>varchar</datatype>
+                <columnTitle>Fixation Duration</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="currentFixative">
+                <datatype>varchar</datatype>
+                <columnTitle>Current Fixative</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="processingType">
+                <datatype>varchar</datatype>
+                <columnTitle>Processing Type</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+            <column columnName="embeddingIns">
+                <datatype>varchar</datatype>
+                <columnTitle>Embedding Instructions</columnTitle>
+                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
+                <defaultValueType>FIXED_EDITABLE</defaultValueType>
+                <scale>4000</scale>
+            </column>
+        </columns>
+        <tableTitle>IPC_ProcessingEmbedding</tableTitle>
     </table>
 </tables>

--- a/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
+++ b/onprc_ehr/resources/referenceStudy/datasets/datasets_metadata.xml
@@ -2308,19 +2308,41 @@
         <columns>
             <column columnName="Id">
                 <datatype>varchar</datatype>
+                <columnTitle>Id</columnTitle>
+                <description>Subject identifier</description>
                 <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
+                <nullable>false</nullable>
+                <fk>
+                    <fkDbSchema>study</fkDbSchema>
+                    <fkTable>Animal</fkTable>
+                    <fkColumnName>Id</fkColumnName>
+                </fk>
             </column>
             <column columnName="date">
                 <datatype>timestamp</datatype>
+                <columnTitle>Date</columnTitle>
                 <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+                <nullable>false</nullable>
             </column>
             <column columnName="tissue">
                 <datatype>varchar</datatype>
                 <columnTitle>Organ/Tissue</columnTitle>
+            </column>
+            <column columnName="remark">
+                <datatype>varchar</datatype>
+                <inputType>textarea</inputType>
+                <columnTitle>Remark</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Remark</propertyURI>
+            </column>
+            <column columnName="Description">
+                <datatype>varchar</datatype>
+                <inputType>textarea</inputType>
+                <columnTitle>Description</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#Description</propertyURI>
+                <isHidden>true</isHidden>
+                <shownInInsertView>false</shownInInsertView>
+                <shownInUpdateView>false</shownInUpdateView>
+                <shownInDetailsView>false</shownInDetailsView>
             </column>
             <column columnName="objectid">
                 <datatype>entityid</datatype>
@@ -2331,6 +2353,24 @@
                 <shownInUpdateView>false</shownInUpdateView>
                 <shownInDetailsView>false</shownInDetailsView>
                 <isKeyField>true</isKeyField>
+            </column>
+            <column columnName="parentId">
+                <datatype>varchar</datatype>
+                <columnTitle>Parent Id</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#ParentId</propertyURI>
+                <isHidden>true</isHidden>
+                <shownInInsertView>false</shownInInsertView>
+                <shownInUpdateView>false</shownInUpdateView>
+                <shownInDetailsView>false</shownInDetailsView>
+            </column>
+            <column columnName="taskid">
+                <datatype>varchar</datatype>
+                <columnTitle>Taskid</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#TaskId</propertyURI>
+                <isHidden>true</isHidden>
+                <shownInInsertView>false</shownInInsertView>
+                <shownInUpdateView>false</shownInUpdateView>
+                <shownInDetailsView>false</shownInDetailsView>
             </column>
             <column columnName="project">
                 <datatype>integer</datatype>
@@ -2345,6 +2385,20 @@
                 <datatype>varchar</datatype>
                 <columnTitle>Account</columnTitle>
                 <propertyURI>urn:ehr.labkey.org/#Account</propertyURI>
+            </column>
+            <column columnName="performedby">
+                <datatype>varchar</datatype>
+                <columnTitle>Performed By</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#PerformedBy</propertyURI>
+            </column>
+            <column columnName="requestid">
+                <datatype>varchar</datatype>
+                <columnTitle>Requestid</columnTitle>
+                <propertyURI>urn:ehr.labkey.org/#RequestId</propertyURI>
+                <isHidden>true</isHidden>
+                <shownInInsertView>false</shownInInsertView>
+                <shownInUpdateView>false</shownInUpdateView>
+                <shownInDetailsView>false</shownInDetailsView>
             </column>
             <column columnName="enddate">
                 <datatype>timestamp</datatype>
@@ -2363,6 +2417,676 @@
         </columns>
         <tableTitle>Organ Weights</tableTitle>
     </table>
+
+    <table tableName="PMIC_PETImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_PETImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="project">
+                <datatype>integer</datatype>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+            </column>
+            <column columnName="PETRadioisotope">
+                <datatype>varchar</datatype>
+                <columnTitle>PET Radioisotope</columnTitle>
+            </column>
+            <column columnName="PETDoseMCI">
+                <datatype>double</datatype>
+                <columnTitle>PET Dose(mCi)</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="PETDoseMBQ">
+                <datatype>double</datatype>
+                <columnTitle>PET Dose(MBq)</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="route">
+                <datatype>varchar</datatype>
+                <columnTitle>Route</columnTitle>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="phantom">
+                <datatype>varchar</datatype>
+                <columnTitle>Phantom</columnTitle>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+            </column>
+            <column columnName="ligandAndComments">
+                <datatype>varchar</datatype>
+                <columnTitle>Ligand and Comments</columnTitle>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+            </column>
+            <column columnName="CTACType">
+                <datatype>varchar</datatype>
+                <columnTitle>CTACType</columnTitle>
+            </column>
+            <column columnName="CTACScanRange">
+                <datatype>varchar</datatype>
+                <columnTitle>CTACScanRange</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>PMIC_PETImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_CTImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_CTImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="project">
+                <datatype>integer</datatype>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+            </column>
+            <column columnName="contrastType">
+                <datatype>varchar</datatype>
+                <columnTitle>Contrast Type</columnTitle>
+            </column>
+            <column columnName="contrastAmount">
+                <datatype>double</datatype>
+                <columnTitle>Contrast Amount</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="route">
+                <datatype>varchar</datatype>
+                <columnTitle>Route</columnTitle>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>PMIC_CTImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_SPECTImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_SPECTImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="project">
+                <datatype>integer</datatype>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+            </column>
+            <column columnName="SPECTIsotope">
+                <datatype>varchar</datatype>
+                <columnTitle>SPECT Isotope</columnTitle>
+            </column>
+            <column columnName="SPECTDoseMCI">
+                <datatype>double</datatype>
+                <columnTitle>SPECT Dose(mCi)</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="SPECTDoseMBQ">
+                <datatype>double</datatype>
+                <columnTitle>SPECT Dose(MBq)</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="route">
+                <datatype>varchar</datatype>
+                <columnTitle>Route</columnTitle>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <formatString>0.0000</formatString>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+            </column>
+            <column columnName="ligandAndComments">
+                <datatype>varchar</datatype>
+                <columnTitle>Ligand and Comments</columnTitle>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>PMIC_SPECTImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_AngioImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_AngioImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="project">
+                <datatype>integer</datatype>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+            </column>
+            <column columnName="CTDIvol">
+                <datatype>double</datatype>
+                <columnTitle>CTDIVol</columnTitle>
+                <formatString>0.000</formatString>
+            </column>
+            <column columnName="DLP">
+                <datatype>double</datatype>
+                <columnTitle>DLP</columnTitle>
+                <formatString>0.000</formatString>
+            </column>
+            <column columnName="totalExamDLP">
+                <datatype>double</datatype>
+                <columnTitle>Total Exam DLP</columnTitle>
+                <formatString>0.000</formatString>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+            </column>
+            <column columnName="imageUploadLink">
+                <datatype>varchar</datatype>
+                <columnTitle>Image Upload Link</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>PMIC_AngioImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_USImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_USImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="project">
+                <datatype>integer</datatype>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+            </column>
+            <column columnName="ultrasoundProcedure">
+                <datatype>varchar</datatype>
+                <columnTitle>Ultrasound Procedure</columnTitle>
+            </column>
+            <column columnName="wetLabUse">
+                <datatype>varchar</datatype>
+                <columnTitle>Wet lab use</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>PMIC_USImagingData</tableTitle>
+    </table>
+    <table tableName="PMIC_DEXAImagingData" tableDbType="TABLE">
+        <description>Contains up to one row of PMIC_DEXAImagingData data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="project">
+                <datatype>integer</datatype>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+            </column>
+            <column columnName="chargeType">
+                <datatype>varchar</datatype>
+                <columnTitle>Credit To</columnTitle>
+            </column>
+            <column columnName="examNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Exam Num</columnTitle>
+            </column>
+            <column columnName="accessionNum">
+                <datatype>varchar</datatype>
+                <columnTitle>Accession Num</columnTitle>
+            </column>
+            <column columnName="PMICType">
+                <datatype>varchar</datatype>
+                <columnTitle>PMIC Type</columnTitle>
+            </column>
+            <column columnName="DEXAProcedure">
+                <datatype>varchar</datatype>
+                <columnTitle>DEXA Procedure</columnTitle>
+            </column>
+            <column columnName="animalPosition">
+                <datatype>varchar</datatype>
+                <columnTitle>Animal Position</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>PMIC_DEXAImagingData</tableTitle>
+    </table>
+    <table tableName="IPC_Sectioning" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_Sectioning data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+            </column>
+            <column columnName="paraffinSectioning">
+                <datatype>varchar</datatype>
+                <columnTitle>Paraffin Sectioning</columnTitle>
+            </column>
+            <column columnName="sectionThickness">
+                <datatype>varchar</datatype>
+                <columnTitle>SectionThickness</columnTitle>
+            </column>
+            <column columnName="frozenSectioning">
+                <datatype>varchar</datatype>
+                <columnTitle>Frozen Sectioning</columnTitle>
+            </column>
+            <column columnName="specialIns">
+                <datatype>varchar</datatype>
+                <columnTitle>Special Instructions</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>IPC_Sectioning</tableTitle>
+    </table>
+    <table tableName="IPC_Staining" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_Staining data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+            </column>
+            <column columnName="HAndE">
+                <datatype>varchar</datatype>
+                <columnTitle><![CDATA[H&E]]></columnTitle>
+            </column>
+            <column columnName="specialStain">
+                <datatype>varchar</datatype>
+                <columnTitle>Special Stain</columnTitle>
+            </column>
+            <column columnName="IHC">
+                <datatype>varchar</datatype>
+                <columnTitle>IHC</columnTitle>
+            </column>
+            <column columnName="IHCPrimaryAntibody">
+                <datatype>varchar</datatype>
+                <columnTitle>IHC Primary Antibody</columnTitle>
+            </column>
+            <column columnName="irrelevantAntibody">
+                <datatype>varchar</datatype>
+                <columnTitle>Irrevelant Antibody</columnTitle>
+            </column>
+            <column columnName="RNAScope">
+                <datatype>varchar</datatype>
+                <columnTitle>RNA Scope</columnTitle>
+            </column>
+            <column columnName="other">
+                <datatype>varchar</datatype>
+                <columnTitle>Other</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>IPC_Staining</tableTitle>
+    </table>
+    <table tableName="IPC_SlidePrinting" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_SlidePrinting data for each Animal/Date combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+            </column>
+            <column columnName="projectNotes">
+                <datatype>varchar</datatype>
+                <columnTitle>Project Notes</columnTitle>
+            </column>
+            <column columnName="additionalText">
+                <datatype>varchar</datatype>
+                <columnTitle>Additional text on slide</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>IPC_SlidePrinting</tableTitle>
+    </table>
+    <table tableName="IPC_Other" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_Other data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="serviceAndProducts">
+                <datatype>varchar</datatype>
+                <columnTitle>Service And Products</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>IPC_Other</tableTitle>
+    </table>
+    <table tableName="IPC_ServiceRequestDetails" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_ServiceRequestDetails data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="project">
+                <datatype>integer</datatype>
+                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
+            </column>
+            <column columnName="requestedBy">
+                <datatype>varchar</datatype>
+                <columnTitle>Requested By</columnTitle>
+            </column>
+            <column columnName="email">
+                <datatype>varchar</datatype>
+                <columnTitle>Email</columnTitle>
+            </column>
+            <column columnName="department">
+                <datatype>varchar</datatype>
+                <columnTitle>Department</columnTitle>
+            </column>
+            <column columnName="pathologist">
+                <datatype>varchar</datatype>
+                <columnTitle>Pathologist</columnTitle>
+            </column>
+            <column columnName="investigator">
+                <datatype>varchar</datatype>
+                <columnTitle>Investigator</columnTitle>
+            </column>
+            <column columnName="alias">
+                <datatype>varchar</datatype>
+                <columnTitle>Alias</columnTitle>
+            </column>
+            <column columnName="sampleLocation">
+                <datatype>varchar</datatype>
+                <columnTitle>Sample Dropoff/Pickup Location</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>IPC_ServiceRequestDetails</tableTitle>
+    </table>
+    <table tableName="IPC_CassettePrinting" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_CassettePrinting data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+            </column>
+            <column columnName="PILabel">
+                <datatype>varchar</datatype>
+                <columnTitle>PI Label Text</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>IPC_CassettePrinting</tableTitle>
+    </table>
+    <table tableName="IPC_ProcessingEmbedding" tableDbType="TABLE">
+        <description>Contains up to one row of IPC_ProcessingEmbedding data for each Animal/Date/objectId combination.</description>
+        <columns>
+            <column columnName="Id">
+                <datatype>varchar</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
+                <importAliases>
+                    <importAlias>ptid</importAlias>
+                </importAliases>
+            </column>
+            <column columnName="date">
+                <datatype>timestamp</datatype>
+                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
+                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
+            </column>
+            <column columnName="tissueType">
+                <datatype>varchar</datatype>
+                <columnTitle>Tissue Type</columnTitle>
+            </column>
+            <column columnName="embedding">
+                <datatype>varchar</datatype>
+                <columnTitle>Embedding</columnTitle>
+            </column>
+            <column columnName="fixationMethod">
+                <datatype>varchar</datatype>
+                <columnTitle>Fixation Method</columnTitle>
+            </column>
+            <column columnName="fixationDuration">
+                <datatype>varchar</datatype>
+                <columnTitle>Fixation Duration</columnTitle>
+            </column>
+            <column columnName="currentFixative">
+                <datatype>varchar</datatype>
+                <columnTitle>Current Fixative</columnTitle>
+            </column>
+            <column columnName="processingType">
+                <datatype>varchar</datatype>
+                <columnTitle>Processing Type</columnTitle>
+            </column>
+            <column columnName="embeddingIns">
+                <datatype>varchar</datatype>
+                <columnTitle>Embedding Instructions</columnTitle>
+            </column>
+        </columns>
+        <tableTitle>IPC_ProcessingEmbedding</tableTitle>
+    </table>
+
+
     <table tableName="StudyDetails" tableDbType="TABLE">
         <columns>
             <column columnName="Id">
@@ -2404,1044 +3128,5 @@
             </column>
         </columns>
         <tableTitle>StudyDetails</tableTitle>
-    </table>
-
-    <table tableName="PMIC_PETImagingData" tableDbType="TABLE">
-        <description>Contains up to one row of PMIC_PETImagingData data for each Animal/Date combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="project">
-                <datatype>varchar</datatype>
-                <columnTitle>Charge To</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>ehr</fkDbSchema>
-                    <fkTable>project</fkTable>
-                    <fkColumnName>displayName</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="chargeType">
-                <datatype>varchar</datatype>
-                <columnTitle>Credit To</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_ChargeTypes</fkTable>
-                    <fkColumnName>chargetype</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="examNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Exam Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="accessionNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Accession Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PMICType">
-                <datatype>varchar</datatype>
-                <columnTitle>PMIC Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PETRadioisotope">
-                <datatype>varchar</datatype>
-                <columnTitle>PET Radioisotope</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_PETRadioisotope_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PETDoseMCI">
-                <datatype>double</datatype>
-                <columnTitle>PET Dose(mCi)</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PETDoseMBQ">
-                <datatype>double</datatype>
-                <columnTitle>PET Dose(MBq)</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="route">
-                <datatype>varchar</datatype>
-                <columnTitle>Route</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_Route_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="CTDIvol">
-                <datatype>double</datatype>
-                <columnTitle>CTDIVol</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="DLP">
-                <datatype>double</datatype>
-                <columnTitle>DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="totalExamDLP">
-                <datatype>double</datatype>
-                <columnTitle>Total Exam DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="phantom">
-                <datatype>varchar</datatype>
-                <columnTitle>Phantom</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_Phantom_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="wetLabUse">
-                <datatype>varchar</datatype>
-                <columnTitle>Wet lab use</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_WetLabUse_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="ligandAndComments">
-                <datatype>varchar</datatype>
-                <columnTitle>Ligand and Comments</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="imageUploadLink">
-                <datatype>varchar</datatype>
-                <columnTitle>Image Upload Link</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="CTACType">
-                <datatype>varchar</datatype>
-                <columnTitle>CTACType</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="CTACScanRange">
-                <datatype>varchar</datatype>
-                <columnTitle>CTACScanRange</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>PMIC_PETImagingData</tableTitle>
-    </table>
-    <table tableName="PMIC_CTImagingData" tableDbType="TABLE">
-        <description>Contains up to one row of PMIC_CTImagingData data for each Animal/Date combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="project">
-                <datatype>varchar</datatype>
-                <columnTitle>Charge To</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>ehr</fkDbSchema>
-                    <fkTable>project</fkTable>
-                    <fkColumnName>displayName</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="chargeType">
-                <datatype>varchar</datatype>
-                <columnTitle>Credit To</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_ChargeTypes</fkTable>
-                    <fkColumnName>chargetype</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="examNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Exam Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="accessionNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Accession Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PMICType">
-                <datatype>varchar</datatype>
-                <columnTitle>PMIC Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="contrastType">
-                <datatype>varchar</datatype>
-                <columnTitle>Contrast Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_CTContrastType_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="contrastAmount">
-                <datatype>double</datatype>
-                <columnTitle>Contrast Amount</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="route">
-                <datatype>varchar</datatype>
-                <columnTitle>Route</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_Route_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="CTDIvol">
-                <datatype>double</datatype>
-                <columnTitle>CTDIVol</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="DLP">
-                <datatype>double</datatype>
-                <columnTitle>DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="totalExamDLP">
-                <datatype>double</datatype>
-                <columnTitle>Total Exam DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="wetLabUse">
-                <datatype>varchar</datatype>
-                <columnTitle>Wet lab use</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_WetLabUse_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="imageUploadLink">
-                <datatype>varchar</datatype>
-                <columnTitle>Image Upload Link</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>PMIC_CTImagingData</tableTitle>
-    </table>
-    <table tableName="PMIC_SPECTImagingData" tableDbType="TABLE">
-        <description>Contains up to one row of PMIC_SPECTImagingData data for each Animal/Date combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="project">
-                <datatype>varchar</datatype>
-                <columnTitle>Charge To</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>ehr</fkDbSchema>
-                    <fkTable>project</fkTable>
-                    <fkColumnName>displayName</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="chargeType">
-                <datatype>varchar</datatype>
-                <columnTitle>Credit To</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_ChargeTypes</fkTable>
-                    <fkColumnName>chargetype</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="examNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Exam Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="accessionNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Accession Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PMICType">
-                <datatype>varchar</datatype>
-                <columnTitle>PMIC Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="SPECTIsotope">
-                <datatype>varchar</datatype>
-                <columnTitle>SPECT Isotope</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="SPECTDoseMCI">
-                <datatype>double</datatype>
-                <columnTitle>SPECT Dose(mCi)</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="SPECTDoseMBQ">
-                <datatype>double</datatype>
-                <columnTitle>SPECT Dose(MBq)</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="route">
-                <datatype>varchar</datatype>
-                <columnTitle>Route</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_Route_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="CTDIvol">
-                <datatype>double</datatype>
-                <columnTitle>CTDIVol</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="DLP">
-                <datatype>double</datatype>
-                <columnTitle>DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="totalExamDLP">
-                <datatype>double</datatype>
-                <columnTitle>Total Exam DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.0000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="wetLabUse">
-                <datatype>varchar</datatype>
-                <columnTitle>Wet lab use</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_WetLabUse_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="ligandAndComments">
-                <datatype>varchar</datatype>
-                <columnTitle>Ligand and Comments</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="imageUploadLink">
-                <datatype>varchar</datatype>
-                <columnTitle>Image Upload Link</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>PMIC_SPECTImagingData</tableTitle>
-    </table>
-    <table tableName="PMIC_AngioImagingData" tableDbType="TABLE">
-        <description>Contains up to one row of PMIC_AngioImagingData data for each Animal/Date combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="project">
-                <datatype>varchar</datatype>
-                <columnTitle>Charge To</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>ehr</fkDbSchema>
-                    <fkTable>project</fkTable>
-                    <fkColumnName>displayName</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="chargeType">
-                <datatype>varchar</datatype>
-                <columnTitle>Credit To</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_ChargeTypes</fkTable>
-                    <fkColumnName>chargetype</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="examNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Exam Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="accessionNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Accession Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PMICType">
-                <datatype>varchar</datatype>
-                <columnTitle>PMIC Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="CTDIvol">
-                <datatype>double</datatype>
-                <columnTitle>CTDIVol</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="DLP">
-                <datatype>double</datatype>
-                <columnTitle>DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="totalExamDLP">
-                <datatype>double</datatype>
-                <columnTitle>Total Exam DLP</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#double</rangeURI>
-                <formatString>0.000</formatString>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="wetLabUse">
-                <datatype>varchar</datatype>
-                <columnTitle>Wet lab use</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_WetLabUse_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="imageUploadLink">
-                <datatype>varchar</datatype>
-                <columnTitle>Image Upload Link</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>PMIC_AngioImagingData</tableTitle>
-    </table>
-    <table tableName="PMIC_USImagingData" tableDbType="TABLE">
-        <description>Contains up to one row of PMIC_USImagingData data for each Animal/Date combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="project">
-                <datatype>varchar</datatype>
-                <columnTitle>Charge To</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>ehr</fkDbSchema>
-                    <fkTable>project</fkTable>
-                    <fkColumnName>displayName</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="chargeType">
-                <datatype>varchar</datatype>
-                <columnTitle>Credit To</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_ChargeTypes</fkTable>
-                    <fkColumnName>chargetype</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="examNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Exam Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="accessionNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Accession Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PMICType">
-                <datatype>varchar</datatype>
-                <columnTitle>PMIC Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="ultrasoundProcedure">
-                <datatype>varchar</datatype>
-                <columnTitle>Ultrasound Procedure</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_US_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="wetLabUse">
-                <datatype>varchar</datatype>
-                <columnTitle>Wet lab use</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_WetLabUse_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>PMIC_USImagingData</tableTitle>
-    </table>
-    <table tableName="PMIC_DEXAImagingData" tableDbType="TABLE">
-        <description>Contains up to one row of PMIC_DEXAImagingData data for each Animal/Date combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="project">
-                <datatype>varchar</datatype>
-                <columnTitle>Charge To</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>ehr</fkDbSchema>
-                    <fkTable>project</fkTable>
-                    <fkColumnName>displayName</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="chargeType">
-                <datatype>varchar</datatype>
-                <columnTitle>Credit To</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_ChargeTypes</fkTable>
-                    <fkColumnName>chargetype</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="examNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Exam Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="accessionNum">
-                <datatype>varchar</datatype>
-                <columnTitle>Accession Num</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="PMICType">
-                <datatype>varchar</datatype>
-                <columnTitle>PMIC Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="DEXAProcedure">
-                <datatype>varchar</datatype>
-                <columnTitle>DEXA Procedure</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_DEXA_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="animalPosition">
-                <datatype>varchar</datatype>
-                <columnTitle>Animal Position</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>study</fkDbSchema>
-                    <fkTable>PMIC_DEXA_AnimalPosition_values</fkTable>
-                    <fkColumnName>value</fkColumnName>
-                </fk>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>PMIC_DEXAImagingData</tableTitle>
-    </table>
-    <table tableName="IPC_Sectioning" tableDbType="TABLE">
-        <description>Contains up to one row of IPC_Sectioning data for each Animal/Date/objectId combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="tissueType">
-                <datatype>varchar</datatype>
-                <columnTitle>Tissue Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-            </column>
-            <column columnName="paraffinSectioning">
-                <datatype>varchar</datatype>
-                <columnTitle>Paraffin Sectioning</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="sectionThickness">
-                <datatype>varchar</datatype>
-                <columnTitle>SectionThickness</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="frozenSectioning">
-                <datatype>varchar</datatype>
-                <columnTitle>Frozen Sectioning</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="specialIns">
-                <datatype>varchar</datatype>
-                <columnTitle>Special Instructions</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>IPC_Sectioning</tableTitle>
-    </table>
-    <table tableName="IPC_Staining" tableDbType="TABLE">
-        <description>Contains up to one row of IPC_Staining data for each Animal/Date/objectId combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="tissueType">
-                <datatype>varchar</datatype>
-                <columnTitle>Tissue Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-            </column>
-            <column columnName="HAndE">
-                <datatype>varchar</datatype>
-                <columnTitle><![CDATA[H&E]]></columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="specialStain">
-                <datatype>varchar</datatype>
-                <columnTitle>Special Stain</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="IHC">
-                <datatype>varchar</datatype>
-                <columnTitle>IHC</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="IHCPrimaryAntibody">
-                <datatype>varchar</datatype>
-                <columnTitle>IHC Primary Antibody</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="irrelevantAntibody">
-                <datatype>varchar</datatype>
-                <columnTitle>Irrevelant Antibody</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="RNAScope">
-                <datatype>varchar</datatype>
-                <columnTitle>RNA Scope</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="other">
-                <datatype>varchar</datatype>
-                <columnTitle>Other</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>IPC_Staining</tableTitle>
-    </table>
-    <table tableName="IPC_SlidePrinting" tableDbType="TABLE">
-        <description>Contains up to one row of IPC_SlidePrinting data for each Animal/Date combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="tissueType">
-                <datatype>varchar</datatype>
-                <columnTitle>Tissue Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-            </column>
-            <column columnName="projectNotes">
-                <datatype>varchar</datatype>
-                <columnTitle>Project Notes</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="additionalText">
-                <datatype>varchar</datatype>
-                <columnTitle>Additional text on slide</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>IPC_SlidePrinting</tableTitle>
-    </table>
-    <table tableName="IPC_Other" tableDbType="TABLE">
-        <description>Contains up to one row of IPC_Other data for each Animal/Date/objectId combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="serviceAndProducts">
-                <datatype>varchar</datatype>
-                <columnTitle>Service And Products</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-            </column>
-        </columns>
-        <tableTitle>IPC_Other</tableTitle>
-    </table>
-    <table tableName="IPC_ServiceRequestDetails" tableDbType="TABLE">
-        <description>Contains up to one row of IPC_ServiceRequestDetails data for each Animal/Date/objectId combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="project">
-                <datatype>varchar</datatype>
-                <columnTitle>Center Project</columnTitle>
-                <propertyURI>urn:ehr.labkey.org/#Project</propertyURI>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <dimension>false</dimension>
-                <fk>
-                    <fkDbSchema>ehr</fkDbSchema>
-                    <fkTable>project</fkTable>
-                    <fkColumnName>displayName</fkColumnName>
-                </fk>
-            </column>
-            <column columnName="requestedBy">
-                <datatype>varchar</datatype>
-                <columnTitle>Requested By</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="email">
-                <datatype>varchar</datatype>
-                <columnTitle>Email</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="department">
-                <datatype>varchar</datatype>
-                <columnTitle>Department</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="pathologist">
-                <datatype>varchar</datatype>
-                <columnTitle>Pathologist</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="investigator">
-                <datatype>varchar</datatype>
-                <columnTitle>Investigator</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="alias">
-                <datatype>varchar</datatype>
-                <columnTitle>Alias</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="sampleLocation">
-                <datatype>varchar</datatype>
-                <columnTitle>Sample Dropoff/Pickup Location</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>IPC_ServiceRequestDetails</tableTitle>
-    </table>
-    <table tableName="IPC_CassettePrinting" tableDbType="TABLE">
-        <description>Contains up to one row of IPC_CassettePrinting data for each Animal/Date/objectId combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="tissueType">
-                <datatype>varchar</datatype>
-                <columnTitle>Tissue Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-            </column>
-            <column columnName="PILabel">
-                <datatype>varchar</datatype>
-                <columnTitle>PI Label Text</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>IPC_CassettePrinting</tableTitle>
-    </table>
-    <table tableName="IPC_ProcessingEmbedding" tableDbType="TABLE">
-        <description>Contains up to one row of IPC_ProcessingEmbedding data for each Animal/Date/objectId combination.</description>
-        <columns>
-            <column columnName="Id">
-                <datatype>varchar</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#ParticipantId</propertyURI>
-                <importAliases>
-                    <importAlias>ptid</importAlias>
-                </importAliases>
-            </column>
-            <column columnName="date">
-                <datatype>timestamp</datatype>
-                <propertyURI>http://cpas.labkey.com/Study#VisitDate</propertyURI>
-                <conceptURI>http://cpas.labkey.com/Study#VisitDate</conceptURI>
-            </column>
-            <column columnName="tissueType">
-                <datatype>varchar</datatype>
-                <columnTitle>Tissue Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-            </column>
-            <column columnName="embedding">
-                <datatype>varchar</datatype>
-                <columnTitle>Embedding</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="fixationMethod">
-                <datatype>varchar</datatype>
-                <columnTitle>Fixation Method</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="fixationDuration">
-                <datatype>varchar</datatype>
-                <columnTitle>Fixation Duration</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="currentFixative">
-                <datatype>varchar</datatype>
-                <columnTitle>Current Fixative</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="processingType">
-                <datatype>varchar</datatype>
-                <columnTitle>Processing Type</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-            <column columnName="embeddingIns">
-                <datatype>varchar</datatype>
-                <columnTitle>Embedding Instructions</columnTitle>
-                <rangeURI>http://www.w3.org/2001/XMLSchema#string</rangeURI>
-                <defaultValueType>FIXED_EDITABLE</defaultValueType>
-            </column>
-        </columns>
-        <tableTitle>IPC_ProcessingEmbedding</tableTitle>
     </table>
 </tables>


### PR DESCRIPTION
#### Rationale
New SQL queries were added recently that depend on newly added study datasets. We need those in the study archive to keep the tests happy during query validation.

#### Changes
* Add missing new PMIC and IPC datasets
* Reference shared column configuration in organ_weights