### PR TITLE
20.11 fb covid s cheduler temp tables

### DIFF
--- a/onprc_ehr/resources/data/procedure_drug_templates.tsv
+++ b/onprc_ehr/resources/data/procedure_drug_templates.tsv
@@ -1,4 +1,4 @@
-value	sort_order
+`value	sort_order
 None
 Analgesia - Standard
 Analgesia - Biopsies

--- a/onprc_ehr/resources/etls/MHC_Typing.xml
+++ b/onprc_ehr/resources/etls/MHC_Typing.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>PRIME-seq MHC Data</name>
+    <description>Syncs MHC Typing Data from PRIME-seq</description>
+    <transforms>
+        <transform type="RemoteQueryTransformStep" id="assay">
+            <description>Copy to target</description>
+            <source remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_data_source">
+                <sourceColumns>
+                    <column>Id</column>
+                    <column>allele</column>
+                    <column>shortName</column>
+                    <column>totalTests</column>
+                    <column>result</column>
+                    <column>type</column>
+                </sourceColumns>
+            </source>
+            <destination schemaName="geneticscore" queryName="mhc_data" targetOption="truncate" bulkLoad="true">
+
+            </destination>
+        </transform>
+    </transforms>
+
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" />
+    <schedule>
+        <cron expression="0 20 2 * * ?"/>
+    </schedule>
+</etl>

--- a/onprc_ehr/resources/etls/eIACUCtoPrime.xml
+++ b/onprc_ehr/resources/etls/eIACUCtoPrime.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<etl xmlns="http://labkey.org/etl/xml">
+
+    <name>eiACUCtoPrime</name>
+
+    <description>Transfers from the eIACUC Import tables to the Prime tables in ONPRC_EHR</description>
+
+
+    <transforms>
+
+
+        <transform id="step1a">
+
+            <description>Transfer to eIACUC Animal Groups</description>
+
+            <source schemaName="eIACUC" queryName="PRIME_VIEW_ANIMAL_GROUPS"/>
+
+            <destination schemaName="ONPRC_EHR" queryName="eIACUC_PRIME_VIEW_ANIMAL_GROUPS" targetOption="truncate" />
+
+        </transform>
+
+        <transform id="step2a">
+
+            <description>Transfer to IBX Numbers</description>
+
+            <source schemaName="eIACUC" queryName="PRIME_VIEW_IBC_NUMBERS"/>
+
+            <destination schemaName="ONPRC_EHR" queryName="eIACUC_PRIME_VIEW_IBC_NUMBERS" targetOption="truncate"/>
+
+        </transform>
+
+        <transform id="step3a">
+
+            <description>Transfer to Non Surgical Procedures</description>
+
+            <source schemaName="eIACUC" queryName="PRIME_VIEW_NON_SURGICAL_PROCS"/>
+
+            <destination schemaName="ONPRC_EHR" queryName="eIACUC_PRIME_VIEW_NON_SURGICAL_PROCS" targetOption="truncate"/>
+
+        </transform>
+
+        <transform id="step4a">
+
+            <description>Transfer to Protocols</description>
+
+            <source schemaName="eIACUC" queryName="PRIME_VIEW_PROTOCOLS"/>
+
+            <destination schemaName="ONPRC_EHR" queryName="eIACUC_PRIME_VIEW_PROTOCOLS" targetOption="truncate"/>
+
+        </transform>
+
+
+        <transform id="step5a">
+
+            <description>Transfer to Surgical Procedures</description>
+
+            <source schemaName="eIACUC" queryName="PRIME_VIEW_SURGERIES"/>
+
+            <destination schemaName="ONPRC_EHR" queryName="eIACUC_PRIME_VIEW_SURGICAL_PROCS" targetOption="truncate"/>
+
+        </transform>
+
+        <!--
+
+                &lt;!&ndash;Need to update to change the processes and document each one&ndash;&gt;
+                <transform id="Stored_ProcStep10" type="StoredProcedure">
+                    <description>Runs a stored procedure tocapture information from the eIACUC Protocol Table.</description>
+                    <procedure schemaName="ONPRC_EHR" procedureName="etlStep1eIACUCtoPRIMEProcessing">
+                    </procedure>
+                </transform>
+
+
+                <transform id="Stored_ProcStep20" type="StoredProcedure">
+                    <description>Runs a stored procedure to process records from eIACUC to temp to ehr.protocol.</description>
+                    <procedure schemaName="ONPRC_EHR" procedureName="etlStep2eIACUCtoPublicAction">
+                    </procedure>
+                </transform>
+
+                <transform id="Stored_ProcStep30" type="StoredProcedure">
+                    <description>Runs a stored procedure identify record updated from eIACUC2 to ehrProtocol ending ehrProtocol Record.</description>
+                    <procedure schemaName="ONPRC_EHR" procedureName="etlStep3update_ehrProtocol">
+                    </procedure>
+                </transform>
+
+                <transform id="Stored_ProcStep40" type="StoredProcedure">
+                    <description>Runs a stored procedure to insert new and updated records from eIACUC to ehrProtocol and update log.</description>
+                    <procedure schemaName="ONPRC_EHR" procedureName="etlStep4insertToEhr_Protocol">
+                    </procedure>
+                </transform>
+
+
+
+
+
+
+        -->
+
+    </transforms>
+    <!--	<schedule>
+
+            <poll interval="12h"/>
+
+        </schedule>-->
+
+
+</etl>
+
+
+
+


### PR DESCRIPTION
#### Rationale
This is a series of SQL Scripts that update the public temp files used for Covid 19 Processing of Scheduler items

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Added script 401 to 409 and updated the extSchedulerModule number to reflect the change
