### PR TITLE
20.11 fb ext sch covid

### DIFF
--- a/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-21.002-21.003.sql
+++ b/extscheduler/resources/schemas/dbscripts/sqlserver/extscheduler-21.002-21.003.sql
@@ -1,0 +1,1 @@
+ALTER TABLE extscheduler.Events ADD  DateDisabled smalldatetime;

--- a/extscheduler/src/org/labkey/extscheduler/ExtSchedulerModule.java
+++ b/extscheduler/src/org/labkey/extscheduler/ExtSchedulerModule.java
@@ -27,7 +27,7 @@ public class ExtSchedulerModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.002;
+        return 21.003;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Added a new field "DateDisabled" to extscheduler.events db table.



#### Changes
This change is helpful to schedule covid testing appointments
