### PR TITLE
New ETL to trigger Stored Procedures for DCM Covid 19 Processing

### DIFF
--- a/onprc_ehr/resources/etls/extSchedulerCovid19_DCMProcess.xml
+++ b/onprc_ehr/resources/etls/extSchedulerCovid19_DCMProcess.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<etl xmlns="http://labkey.org/etl/xml">
+
+    <name>Covid19Scheduler_DCMProcessing</name>
+
+    <description>This ETL Runs a series of Stored Procedures to Handle Reoccuring events and Parsing</description>
+
+
+    <transforms>
+
+        <transform id="CreateNewfromReoccurringEvent" type="StoredProcedure">
+            <description>Runs a stored procedure that determines if an event spans several dates and creates new Events for each</description>
+            <procedure schemaName="extscheduler" procedureName="Covid19_ScheduleProcessDCM">
+            </procedure>
+        </transform>
+
+        <transform id="ParseDCMComments" type="StoredProcedure">
+            <description>This Procedure parses multiple users from comments field to new events</description>
+            <procedure schemaName="extscheduler" procedureName="Covid19_ReoccurringEvents">
+            </procedure>
+        </transform>
+
+
+    </transforms>
+    <!--	<schedule>
+
+            <poll interval="12h"/>
+
+        </schedule>-->
+
+
+</etl>
+
+
+
+


### PR DESCRIPTION
#### Rationale
ETL created to initiate the Stored Procedures for Reoccurring events and Parsing DCM Events

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New ETL
