### PR TITLE
Ticket 43341: Existing version of surgery template is not working

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/window/SurgeryPostOpMedsWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/SurgeryPostOpMedsWindow.js
@@ -142,7 +142,7 @@ Ext4.define('onprc_ehr.window.SurgeryPostOpMedsWindow', {
             if (r.get('date')){
                 items.push({
                     xtype: 'displayfield',
-                    value: r.get('date').format('H:i'),
+                    value: Ext4.Date.format(r.get('date'), 'H:i'),
                     recIdx: recIdx
                 });
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/EncounterMedicationsFormSection.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/EncounterMedicationsFormSection.java
@@ -36,6 +36,9 @@ public class EncounterMedicationsFormSection extends EncounterChildFormSection
         addClientDependency(ClientDependency.supplierFromPath("ehr/window/SedationWindow.js"));
         addClientDependency(ClientDependency.supplierFromPath("ehr/window/DrugAmountWindow.js"));
         addClientDependency(ClientDependency.supplierFromPath("ehr/window/SurgeryPostOpMedsWindow.js"));
+
+        //        Modified: 10-4-2017  R.Blasa
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/SurgeryPostOpMedsWindow.js"));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
ONPRC has customized the Post Op Meds dialog, but the reference to its JS file got missed in the merge to 20.11

#### Changes
* Restore client dependency declaration