### PR TITLE
Add ETL to sync MHC data from prime-seq to prime

### DIFF
--- a/onprc_ehr/resources/etl/MHC_Typing.xml
+++ b/onprc_ehr/resources/etl/MHC_Typing.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>PRIME-seq MHC Data</name>
+    <description>Syncs MHC Typing Data from PRIME-seq</description>
+    <transforms>
+        <transform type="RemoteQueryTransformStep" id="assay">
+            <description>Copy to target</description>
+            <source remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_data">
+                <sourceColumns>
+                    <column>Id</column>
+                    <column>allele</column>
+                    <column>shortName</column>
+                    <column>totalTests</column>
+                    <column>result</column>
+                    <column>type</column>
+                    <column>objectid</column>
+                </sourceColumns>
+            </source>
+            <destination schemaName="geneticscore" queryName="mhc_data" targetOption="truncate" bulkLoad="true">
+                <alternateKeys>
+                    <column name="objectid"/>
+                </alternateKeys>
+            </destination>
+        </transform>
+    </transforms>
+
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
+        <deletedRowsSource schemaName="geneticscore" queryName="mhc_delete_source" deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
+    </incrementalFilter>
+    <schedule>
+        <cron expression="0 20 2 * * ?"/>
+    </schedule>
+</etl>


### PR DESCRIPTION
@labkey-jeckels  This is related to #181. It separates just the ETL into a release20.11-SNAPSHOT PR. This is the minimal file I need deployed to PRIMe for this ETL. The other PR can be 21.3 and will be deployed to prime-seq.

I think we want release20.11-SNAPSHOT, not release20.11, right?