### PR TITLE
Add ETL pull MHC data from prime-seq

### DIFF
--- a/onprc_ehr/resources/etls/MHC_Typing.xml
+++ b/onprc_ehr/resources/etls/MHC_Typing.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>PRIME-seq MHC Data</name>
+    <description>Syncs MHC Typing Data from PRIME-seq</description>
+    <transforms>
+        <transform type="RemoteQueryTransformStep" id="assay">
+            <description>Copy to target</description>
+            <source remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_data">
+                <sourceColumns>
+                    <column>Id</column>
+                    <column>allele</column>
+                    <column>shortName</column>
+                    <column>totalTests</column>
+                    <column>result</column>
+                    <column>type</column>
+                    <column>objectid</column>
+                </sourceColumns>
+            </source>
+            <destination schemaName="geneticscore" queryName="mhc_data" targetOption="truncate" bulkLoad="true">
+                <alternateKeys>
+                    <column name="objectid"/>
+                </alternateKeys>
+            </destination>
+        </transform>
+    </transforms>
+
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
+        <deletedRowsSource schemaName="geneticscore" queryName="mhc_delete_source" deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
+    </incrementalFilter>
+    <schedule>
+        <cron expression="0 20 2 * * ?"/>
+    </schedule>
+</etl>


### PR DESCRIPTION
#### Rationale
PRIMe is going to run an ETL to pull MHC data from prime-seq regularly

#### Changes
* Add new ETL