### PR TITLE
Fix PG syntax making column non-nullable

### DIFF
--- a/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.12-17.13.sql
+++ b/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.12-17.13.sql
@@ -1,3 +1,3 @@
 ALTER TABLE geneticscore.mhc_data DROP CONSTRAINT PK_mhc_data;
-ALTER TABLE geneticscore.mhc_data ALTER COLUMN objectid NOT NULL;
+ALTER TABLE geneticscore.mhc_data ALTER COLUMN objectid SET NOT NULL;
 ALTER TABLE geneticscore.mhc_data ADD CONSTRAINT PK_mhc_data PRIMARY KEY (objectid);


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_213Release_Premium_Ehr_DailyEhrPostgres/1448197?buildTab=artifacts

#### Changes
* Add the required "SET" to the ALTER COLUMN statement
