### PR TITLE
Backport schema changes for MHC ETL

### DIFF
--- a/GeneticsCore/resources/etl/MHC_Typing.xml
+++ b/GeneticsCore/resources/etl/MHC_Typing.xml
@@ -5,7 +5,7 @@
     <transforms>
         <transform type="RemoteQueryTransformStep" id="assay">
             <description>Copy to target</description>
-            <source remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_data_source">
+            <source remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_data">
                 <sourceColumns>
                     <column>Id</column>
                     <column>allele</column>
@@ -13,15 +13,20 @@
                     <column>totalTests</column>
                     <column>result</column>
                     <column>type</column>
+                    <column>objectid</column>
                 </sourceColumns>
             </source>
-            <destination schemaName="geneticscore" queryName="mhc_data" targetOption="truncate" bulkLoad="true">
-
+            <destination schemaName="geneticscore" queryName="mhc_data" targetOption="merge" bulkLoad="true" batchSize="1000">
+                <alternateKeys>
+                    <column name="objectid"/>
+                </alternateKeys>
             </destination>
         </transform>
     </transforms>
 
-    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified" />
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
+        <deletedRowsSource schemaName="geneticscore" queryName="mhc_delete_source" deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
+    </incrementalFilter>
     <schedule>
         <cron expression="0 20 2 * * ?"/>
     </schedule>

--- a/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.11-17.12.sql
+++ b/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.11-17.12.sql
@@ -1,0 +1,2 @@
+ALTER TABLE geneticscore.mhc_data ADD objectid ENTITYID;
+ALTER TABLE geneticscore.mhc_data ADD totalTests int;

--- a/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.12-17.13.sql
+++ b/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.12-17.13.sql
@@ -1,0 +1,3 @@
+ALTER TABLE geneticscore.mhc_data DROP CONSTRAINT PK_mhc_data;
+ALTER TABLE geneticscore.mhc_data ALTER COLUMN objectid SET NOT NULL;
+ALTER TABLE geneticscore.mhc_data ADD CONSTRAINT PK_mhc_data PRIMARY KEY (objectid);

--- a/GeneticsCore/resources/schemas/dbscripts/sqlserver/geneticscore-17.11-17.12.sql
+++ b/GeneticsCore/resources/schemas/dbscripts/sqlserver/geneticscore-17.11-17.12.sql
@@ -1,0 +1,2 @@
+ALTER TABLE geneticscore.mhc_data ADD objectid ENTITYID;
+ALTER TABLE geneticscore.mhc_data ADD totalTests int;

--- a/GeneticsCore/resources/schemas/dbscripts/sqlserver/geneticscore-17.12-17.13.sql
+++ b/GeneticsCore/resources/schemas/dbscripts/sqlserver/geneticscore-17.12-17.13.sql
@@ -1,0 +1,4 @@
+ALTER TABLE geneticscore.mhc_data DROP CONSTRAINT PK_mhc_data;
+ALTER TABLE geneticscore.mhc_data ALTER COLUMN objectid entityid NOT NULL;
+GO
+ALTER TABLE geneticscore.mhc_data ADD CONSTRAINT PK_mhc_data PRIMARY KEY (objectid);

--- a/GeneticsCore/resources/schemas/geneticscore.xml
+++ b/GeneticsCore/resources/schemas/geneticscore.xml
@@ -18,9 +18,9 @@
  -->
 <ns:tables xmlns:ns="http://labkey.org/data/xml">
     <ns:table tableName="mhc_data" tableDbType="TABLE">
-        <ns:javaCustomizer>org.labkey.ehr.table.DefaultEHRCustomizer</ns:javaCustomizer>
+        <ns:javaCustomizer class="org.labkey.ldk.query.DefaultTableCustomizer" />
         <ns:tableTitle>MHC Data</ns:tableTitle>
-        <ns:pkColumnName>rowId</ns:pkColumnName>
+        <ns:pkColumnName>objectid</ns:pkColumnName>
         <ns:columns>
             <ns:column columnName="rowid">
                 <ns:columnTitle>Row Id</ns:columnTitle>
@@ -44,6 +44,15 @@
             <ns:column columnName="assaytype">
                 <ns:columnTitle>Assay Type</ns:columnTitle>
             </ns:column>
+            <ns:column columnName="objectid">
+                <ns:columnTitle>Key</ns:columnTitle>
+                <ns:isHidden>true</ns:isHidden>
+                <ns:isUserEditable>false</ns:isUserEditable>
+                <ns:isKeyField>true</ns:isKeyField>
+            </ns:column>
+            <ns:column columnName="totalTests">
+                <ns:columnTitle># Tests</ns:columnTitle>
+            </ns:column>
             <ns:column columnName="container">
                 <ns:columnTitle>Folder</ns:columnTitle>
             </ns:column>
@@ -62,7 +71,7 @@
         </ns:columns>
     </ns:table>
     <ns:table tableName="taqman_probes" tableDbType="TABLE">
-        <ns:javaCustomizer>org.labkey.ldk.query.DefaultTableCustomizer</ns:javaCustomizer>
+        <ns:javaCustomizer class="org.labkey.ldk.query.DefaultTableCustomizer"/>
         <ns:tableTitle>Taqman Probes</ns:tableTitle>
         <ns:pkColumnName>rowId</ns:pkColumnName>
         <ns:columns>
@@ -93,7 +102,7 @@
         </ns:columns>
     </ns:table>
     <ns:table tableName="test_significance" tableDbType="TABLE">
-        <ns:javaCustomizer>org.labkey.ldk.query.DefaultTableCustomizer</ns:javaCustomizer>
+        <ns:javaCustomizer class="org.labkey.ldk.query.DefaultTableCustomizer"/>
         <ns:tableTitle>Genetic Test Significance</ns:tableTitle>
         <ns:pkColumnName>rowId</ns:pkColumnName>
         <ns:columns>

--- a/GeneticsCore/src/org/labkey/GeneticsCore/GeneticsCoreModule.java
+++ b/GeneticsCore/src/org/labkey/GeneticsCore/GeneticsCoreModule.java
@@ -39,7 +39,7 @@ public class GeneticsCoreModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 17.11;
+        return 17.13;
     }
 
     @Override


### PR DESCRIPTION
@labkey-jeckels If you remember, I am splitting the MHC ETL changes into those targeting PRIMe/20.11, and those targeting prime-seq/213. I missed one change we need on PRIMe. This backports the changes in the mhc_data table to 20.11 so we can deploy to prime. Note: I fixed the PG "set" error you caught on develop here. This might make merge conflicts downstream, but i'm not sure how to best approach this otherwise