### PR TITLE
Update MHC_Typing.xml to remove remote deletedRowsSource

### DIFF
--- a/GeneticsCore/resources/etls/MHC_Typing.xml
+++ b/GeneticsCore/resources/etls/MHC_Typing.xml
@@ -25,7 +25,8 @@
     </transforms>
 
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
-        <deletedRowsSource schemaName="geneticscore" queryName="mhc_delete_source" deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>
+        <!--TODO: re-enable this once LK supports remote delete sources-->
+        <!--<deletedRowsSource remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_delete_source" deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid"/>-->
     </incrementalFilter>
     <schedule>
         <cron expression="0 20 2 * * ?"/>


### PR DESCRIPTION
This is related to getting MHC data ETL'd from prime-seq to prime. Since LK doesnt currently support remote deletedRowsSource, disable for the time being