### PR TITLE
Update MHC_Data_Animals.sql

### DIFF
--- a/onprc_reports/resources/queries/sequenceanalysis/MHC_Data_Animals.sql
+++ b/onprc_reports/resources/queries/sequenceanalysis/MHC_Data_Animals.sql
@@ -1,26 +1,5 @@
 SELECT
-  s.subjectId as Id,
-  --NOTE: we initially cast a very wide net, allowing animals with either SSP data, or those with any reads imported.
-  --The latter can be deceptive, so we also track whether we have published results
-  null as hasSBTData
-FROM assay.SSP_assay.SSP.Data s
-WHERE s.subjectId is not null AND s.result != 'FAIL' and s.result != 'IND'
+    m.subjectId as Id,
+    true as hasSBTData
 
-UNION ALL
-
-SELECT
-  a.subjectId as Id,
-  null as hasSBTData
-
-FROM sequenceanalysis.sequence_readsets a
-WHERE a.subjectId is not null
-AND (a.status IS NULL OR a.status != 'Fail')
-
-UNION ALL
-
-SELECT
-  a.subjectId as Id,
-  true as hasSBTData
-
-FROM assay.GenotypeAssay.Genotype.Data a
-WHERE a.run.assayType = 'SBT'
+FROM geneticscore.mhc_data m


### PR DESCRIPTION
This change is related to the prior MHC-data changes. The data of reference for MHC now resides on prime-seq. As a result, we need to base this query (which governs other queries to show which animals have MHC data), on the cached MHC data table