### PR TITLE
Restore code unintentionally deleted in late 20.11 FB

### DIFF
--- a/onprc_ehr/resources/schemas/onprc_ehr.xml
+++ b/onprc_ehr/resources/schemas/onprc_ehr.xml
@@ -1089,4 +1089,221 @@
         </columns>
     </table>
 
+    <!--Prima db tables. Added by Kolli, 07/26/2021 -->
+    <table tableName="Prima_UserPersons" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="DateOfBirth" />
+            <column columnName="DepartmentName" />
+            <column columnName="FirstName" />
+            <column columnName="Gender" />
+            <column columnName="LastName" />
+            <column columnName="MiddleName" />
+            <column columnName="Prefix" />
+            <column columnName="SSN" />
+            <column columnName="ProfessionalTitles" />
+            <column columnName="DateOfDeath" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_SurgicalWheels" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="Constant" />
+            <column columnName="Description" />
+            <column columnName="IsActive" />
+            <column columnName="CreatedByUserId" />
+            <column columnName="Deleted" />
+            <column columnName="DeletedByUserId" />
+            <column columnName="NextVersionId" />
+            <column columnName="PreviousVersionId" />
+            <column columnName="Title" />
+            <column columnName="Created" />
+            <column columnName="LastModified" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_StainTests" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="Abbreviation" />
+            <column columnName="Constant" />
+            <column columnName="CptCode" />
+            <column columnName="Description" />
+            <column columnName="StainTestCategoryId" />
+            <column columnName="TimeLength" />
+            <column columnName="CreatedByUserId" />
+            <column columnName="Deleted" />
+            <column columnName="DeletedByUserId" />
+            <column columnName="NextVersionId" />
+            <column columnName="PreviousVersionId" />
+            <column columnName="Title" />
+            <column columnName="Created" />
+            <column columnName="LastModified" />
+            <column columnName="IsValidated" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_SlideBases" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="HandStain" />
+            <column columnName="IsCharged" />
+            <column columnName="StainTestId" />
+            <column columnName="DilutionFactor" />
+            <column columnName="CaseBaseId" />
+            <column columnName="IsRadioActive" />
+            <column columnName="PriorityLevelId" />
+            <column columnName="QcStatus" />
+            <column columnName="SurgicalSerialPart" />
+            <column columnName="Created" />
+            <column columnName="OrderedStatus" />
+            <column columnName="SavedIdentifier" />
+            <column columnName="BarcodeContent" />
+            <column columnName="CurrentBatchId" />
+            <column columnName="AlternateIdentifier" />
+            <column columnName="PrintStatus" />
+            <column columnName="ItemStatus" />
+            <column columnName="FreeTextNotes" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_CaseBase" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="DifferentialDiagnosisId" />
+            <column columnName="PathologistId" />
+            <column columnName="PriorityLevelId" />
+            <column columnName="ResidentPathologistId" />
+            <column columnName="SerialNumber" />
+            <column columnName="SurgeryDate" />
+            <column columnName="SurgicalWheelId" />
+            <column columnName="Created" />
+            <column columnName="ResearcherId" />
+            <column columnName="StudyId" />
+            <column columnName="Discriminator" />
+            <column columnName="StudyPhaseId" />
+            <column columnName="CohortId" />
+            <column columnName="SavedIdentifier" />
+            <column columnName="Status" />
+            <column columnName="AlternateIdentifier" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_CassetteEvents" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="CassetteBaseId" />
+            <column columnName="EventType" />
+            <column columnName="Status" />
+            <column columnName="Trigger" />
+            <column columnName="UserId" />
+            <column columnName="Created" />
+            <column columnName="EventAction" />
+            <column columnName="TissueProcessorId" />
+            <column columnName="TissueProcessorProgramId" />
+            <column columnName="Discriminator" />
+            <column columnName="CassetteBatchId" />
+            <column columnName="CassetteOrderId" />
+            <column columnName="AutomatedCassetteArchivalMachineId" />
+            <column columnName="DisposalReasonId" />
+            <column columnName="ShipmentId" />
+            <column columnName="IsEstimated" />
+            <column columnName="PrintCount" />
+            <column columnName="BarcodeContent" />
+
+        </columns>
+    </table>
+
+    <table tableName="Prima_CassetteEventLocations" tableDbType="TABLE">
+        <columns>
+            <column columnName="CassetteEventId" />
+            <column columnName="LabStationTypeId" />
+            <column columnName="LocationId" />
+            <column columnName="WorkstationId" />
+            <column columnName="Created" />
+            <column columnName="PersonId" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_CassetteBases" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="CassetteColorId" />
+            <column columnName="EmbeddingInstructionId" />
+            <column columnName="EmbeddingNotes" />
+            <column columnName="HasTissue" />
+            <column columnName="ProtocolCassetteId" />
+            <column columnName="SpecimenBaseId" />
+            <column columnName="TissueCollectionId" />
+            <column columnName="TissueProcessorProgramId" />
+            <column columnName="TissueQuantity" />
+            <column columnName="CaseBaseId" />
+            <column columnName="IsRadioActive" />
+            <column columnName="PriorityLevelId" />
+            <column columnName="QcStatus" />
+            <column columnName="SurgicalSerialPart" />
+            <column columnName="Created" />
+            <column columnName="OrderedStatus" />
+            <column columnName="SavedIdentifier" />
+            <column columnName="BarcodeContent" />
+            <column columnName="CurrentBatchId" />
+            <column columnName="AlternateIdentifier" />
+            <column columnName="PrintStatus" />
+            <column columnName="ItemStatus" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_LabstationTypes" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="CanProcess" />
+            <column columnName="Constant" />
+            <column columnName="Description" />
+            <column columnName="IsEnabled" />
+            <column columnName="Order" />
+            <column columnName="Title" />
+            <column columnName="Created" />
+            <column columnName="LastModified" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_SlideEvents" tableDbType="TABLE">
+        <columns>
+            <column columnName="Id" />
+            <column columnName="SlideBaseId" />
+            <column columnName="EventType" />
+            <column columnName="Status" />
+            <column columnName="Trigger" />
+            <column columnName="UserId" />
+            <column columnName="Created" />
+            <column columnName="EventAction" />
+            <column columnName="CoverSlipperId" />
+            <column columnName="OvenId" />
+            <column columnName="OvenProgramId" />
+            <column columnName="SlideImagerId" />
+            <column columnName="SlideStainerId" />
+            <column columnName="Discriminator" />
+            <column columnName="SlideBatchId" />
+            <column columnName="SlideOrderId" />
+            <column columnName="DisposalReasonId" />
+            <column columnName="ShipmentId" />
+            <column columnName="PrintCount" />
+            <column columnName="BarcodeContent" />
+            <column columnName="EquipmentId" />
+            <column columnName="AutomatedSlideArchivalMachineId" />
+        </columns>
+    </table>
+
+    <table tableName="Prima_SlideEventLocations" tableDbType="TABLE">
+        <columns>
+            <column columnName="SlideEventId" />
+            <column columnName="LabStationTypeId" />
+            <column columnName="LocationId" />
+            <column columnName="WorkstationId" />
+            <column columnName="Created" />
+            <column columnName="PersonId" />
+        </columns>
+    </table>
+
 </tables>

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
@@ -78,6 +78,7 @@ import org.labkey.onprc_ehr.demographics.ParentsDemographicsProvider;
 import org.labkey.onprc_ehr.demographics.PregnancyConfirmDemographicsProvider;
 import org.labkey.onprc_ehr.demographics.SourceDemographicsProvider;
 import org.labkey.onprc_ehr.demographics.TBDemographicsProvider;
+import org.labkey.onprc_ehr.history.BiopsyHistologyDataSource;
 import org.labkey.onprc_ehr.history.DefaultAnimalGroupsDataSource;
 import org.labkey.onprc_ehr.history.DefaultAnimalGroupsEndDataSource;
 import org.labkey.onprc_ehr.history.DefaultAnimalRecordFlagDataSource;
@@ -610,6 +611,9 @@ public class ONPRC_EHRModule extends ExtendedSimpleModule
         //R.Blasa   1-23-2015
         EHRService.get().registerHistoryDataSource(new org.labkey.api.ehr.history.DefaultAnimalRecordFlagDataSource(this));
         EHRService.get().registerHistoryDataSource(new ONPRCClinicalRemarksDataSource(this));
+
+        //        6-2-2021  R.Blasa
+        EHRService.get().registerHistoryDataSource(new BiopsyHistologyDataSource(this));
 
         EHRService.get().registerMoreActionsButton(new CreateNecropsyRequestButton(this), "study", "encounters");
         EHRService.get().registerMoreActionsButton(new CreateTaskFromRecordsButton(this, "Create Task From Selected", "Necropsy", NecropsyFormType.NAME), "study", "encounters");


### PR DESCRIPTION
#### Rationale
A late breaking 20.11 feature branch included changes from incorrectly reconciled merge conflicts, which removed tables from the schema XML and dropped a clinical history provider. Our automated tests caught these regresssions.

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/243

#### Changes
* Restore missing PRIMA tables to onprc_ehr.xml
* Restore biopsy histology clinical data source