### PR TITLE
21.7 fb update title length

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -1550,7 +1550,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
     {
         ti.getMutableColumn("inves").setHidden(true);
         ti.getMutableColumn("maxAnimals").setHidden(true);
-        ti.getMutableColumn("title").setScale(80);
+        ti.getMutableColumn("title").setScale(200);
         ti.getMutableColumn("investigatorId").setHidden(false);
         ti.getMutableColumn("approve").setLabel("Initial IACUC Approval Date");
         ti.getMutableColumn("enddate").setLabel("Date Disabled");

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -75,6 +75,7 @@ import java.util.Set;
  * User: bimber
  * Date: 12/7/12
  * Time: 2:22 PM
+ * Update Jonesga 2021-=10-01 Update to change length of protocol Title
  */
 public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
 {


### PR DESCRIPTION
#### Rationale
The title field of Protocol was limited to 80 characters which did not allow the full title of a Protocol to be listed.  the NIH Standard for Protocol Titles is 200 characters

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Updated onprc_ERHCustomizer lie1554 by setting scale to 200
