### PR TITLE
Don't try to run ONPRC_EHR_ComplianceDB when on Postgres

### DIFF
--- a/ONPRC_EHR_ComplianceDB/module.properties
+++ b/ONPRC_EHR_ComplianceDB/module.properties
@@ -1,3 +1,4 @@
 Name: ONPRC_EHR_ComplianceDB
 ModuleClass: org.labkey.api.module.SimpleModule
 ModuleDependencies: EHR_ComplianceDB
+SupportedDatabases: mssql


### PR DESCRIPTION
#### Rationale
We're seeing intermittent failures in the crawler like:

https://teamcity.labkey.org/buildConfiguration/LabKey_2111Release_Premium_Ehr_DailyEhrPostgres/1605326?buildTab=overview

#### Changes
* Mark ONPRC_EHR_ComplianceDB as SQL Server only