### PR TITLE
Use `BuildUtils.addLabKeyDependency` for declaring the module dependency

### DIFF
--- a/onprc_ehr/build.gradle
+++ b/onprc_ehr/build.gradle
@@ -19,7 +19,6 @@ dependencies
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ldap", depProjectConfig: 'published', depExtension: 'module')
 
-   BuildUtils.getServerProject(project).dependencies {
-      modules ("org.labkey.module:sampleManagement:${labkeyVersion}@module") { transitive = true }
-   }
+   BuildUtils.addLabKeyDependency(project: BuildUtils.getServerProject(project), config: "modules", depProjectPath: ":server:modules:sampleManagement", depProjectConfig: "published", depExtension: "module")
+
 }


### PR DESCRIPTION
#### Rationale
The dependency declaration to get the SampleManagement module deployed that doesn't use `addLabKeyDependency` causes problems when there is no version of the SampleManagement module already published (such as when we are first building our release versions to publish).  This change will pick up the locally built module if present and otherwise get the module from Artifactory.

One question here is whether it is a problem that this dependency declaration will cause any server distribution containing this module to include the SM module.  This is probably only a question for our test suites.


#### Changes
* Update method for declaring server module dependency.
