### PR TITLE
Fix crawler failure - Declare explicit dependency on EHR JS files

### DIFF
--- a/ONPRC_EHR_ComplianceDB/resources/views/begin.view.xml
+++ b/ONPRC_EHR_ComplianceDB/resources/views/begin.view.xml
@@ -1,5 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Compliance and Training">
     <dependencies>
         <dependency path="LDK/LDKApi"/>
+        <dependency path="ehr.context" />
+        <dependency path="ehr/ehr_api"/>
     </dependencies>
 </view>


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_2111Release_Premium_Ehr_DailyEhrSqlserver/1610374

#### Changes
* Declare dependency on EHR JS files instead of relying on them to be pulled in via other modules being enabled in the container