### PR TITLE
21.7 fb tissue distribution export link

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/panel/TissueDistributionExportPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/TissueDistributionExportPanel.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//Added: 12-16-2021  R.Blasa
+Ext4.define('ONPRC_EHR.panel.TissueDistributionExportPanel', {
+    extend: 'Ext.panel.Panel',
+    alias: 'widget.onprc_ehr-TissueDistributionExportpanel',
+
+    initComponent: function(){
+       var  ctx = EHR.Utils.getEHRContext();
+        Ext4.apply(this, {
+            defaults: {
+                border: false
+            },
+            items: [{
+                html: 'This form allows you to export a Tissue Distribution template into an Excel spreadsheet by clicking the link below. Please enter a monkey id into the "Animal ID" input box, and click "View Report" button ' +
+                        'located to the upper right section of the reporting screen. ' +
+                        ' <br>  After the program has completed generating the report, please select the icon ' +
+                        'to the left of the printer icon, and then choose Excel menu to export into an Excel file.  <p>' ,
+
+                style: 'padding: 5px;'
+            },{
+                xtype: 'ldk-linkbutton',
+                text: '<li>View Tissue Distribution Export Template</li>',
+                href: ctx['SSRSServerURL'] +'%2fPrime+Reports%2fNecropsy%20Reports%2fTissueDistributionTemplates&rs:Command=Render'
+            }]
+        });
+
+        this.callParent(arguments);
+    }
+});

--- a/onprc_ehr/resources/web/onprc_ehr/panel/TissueDistributionExportPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/TissueDistributionExportPanel.js
@@ -17,15 +17,18 @@ Ext4.define('ONPRC_EHR.panel.TissueDistributionExportPanel', {
             },
             items: [{
                 html: 'This form allows you to export a Tissue Distribution template into an Excel spreadsheet by clicking the link below. Please enter a monkey id into the "Animal ID" input box, and click "View Report" button ' +
-                        'located to the upper right section of the reporting screen. ' +
-                        ' <br>  After the program has completed generating the report, please select the icon ' +
+                        '<br> located on the upper right section of the reporting screen. ' +
+                        '  After the program has completed generating the report, please select the icon ' +
                         'to the left of the printer icon, and then choose Excel menu to export into an Excel file.  <p>' ,
 
                 style: 'padding: 5px;'
             },{
                 xtype: 'ldk-linkbutton',
-                text: '<li>View Tissue Distribution Export Template</li>',
+                text: '<li><b>View Tissue Distribution Export Template</li>',
                 href: ctx['SSRSServerURL'] +'%2fPrime+Reports%2fNecropsy%20Reports%2fTissueDistributionTemplates&rs:Command=Render'
+            },{
+                style: 'padding: 10px;',
+                html: ''
             }]
         });
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/PathologyTissuesFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/PathologyTissuesFormType.java
@@ -21,6 +21,7 @@ import org.labkey.api.ehr.dataentry.AnimalDetailsFormSection;
 import org.labkey.api.ehr.dataentry.DataEntryFormContext;
 import org.labkey.api.ehr.dataentry.FormSection;
 import org.labkey.api.ehr.dataentry.SimpleFormPanelSection;
+import org.labkey.onprc_ehr.dataentry.TissueInstructionFormSection;
 import org.labkey.api.ehr.dataentry.SimpleFormSection;
 import org.labkey.api.ehr.dataentry.TaskForm;
 import org.labkey.api.ehr.dataentry.TaskFormSection;
@@ -49,6 +50,7 @@ public class PathologyTissuesFormType extends TaskForm
     {
         super(ctx, owner, NAME, LABEL, "Pathology", Arrays.asList(
                 new TaskFormSection(),
+                new TissueInstructionFormSection(),
                 new AnimalDetailsFormSection(),
                 //                Added:5-31-2017  R.Blasa
                 new ClinicalEncountersFormPanelSection("Pathology Tissues"),

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/TissueInstructionFormSection.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/TissueInstructionFormSection.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.onprc_ehr.dataentry;
+
+import org.labkey.api.ehr.dataentry.AbstractFormSection;
+import org.labkey.api.ehr.dataentry.DataEntryFormContext;
+import org.labkey.api.ehr.dataentry.FormElement;
+import org.labkey.api.view.template.ClientDependency;
+
+import java.util.Collections;
+import java.util.List;
+
+//Added: 12-16-2021  R.Blasa
+public class TissueInstructionFormSection extends AbstractFormSection
+{
+    public TissueInstructionFormSection()
+    {
+        super("TDPExportInstructions", "TDP Export Instructions", "onprc_ehr-TissueDistributionExportpanel");
+
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/panel/TissueDistributionExportpanel.js"));
+    }
+
+    @Override
+    protected List<FormElement> getFormElements(DataEntryFormContext ctx)
+    {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
#### Rationale


#### Related Pull Requests


#### Changes
Provided a web link within the Pathology Tissues input form to allow exporting of previously entered Tissue Distribution records sorted in their original form sort order.  The reporting link is to a SSRS reporting program.
