### PR TITLE
Don't assume JS Date object has a format() function

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/model/sources/ASB_Services.js
+++ b/onprc_ehr/resources/web/onprc_ehr/model/sources/ASB_Services.js
@@ -31,7 +31,7 @@ EHR.model.DataModelManager.registerMetadata('ASB_Services', {
             date: {
                 xtype: 'xdatetime',
                 extFormat: 'Y-m-d H:i',
-                defaultValue: (new Date()).format('Y-m-d 8:0')
+                defaultValue: Ext4.Date.format(new Date(), 'Y-m-d 8:0')
             },
             type: {
                 defaultValue: 'Procedure',
@@ -95,7 +95,7 @@ EHR.model.DataModelManager.registerMetadata('ASB_Services', {
             date: {
                 xtype: 'xdatetime',
                 extFormat: 'Y-m-d H:i',
-                defaultValue: (new Date()).format('Y-m-d 8:0')
+                defaultValue: Ext4.Date.format(new Date(), 'Y-m-d 8:0')
             }
         },
         'study.drug': {
@@ -106,7 +106,7 @@ EHR.model.DataModelManager.registerMetadata('ASB_Services', {
             date: {
                 xtype: 'xdatetime',
                 extFormat: 'Y-m-d H:i',
-                defaultValue: (new Date()).format('Y-m-d 8:0')
+                defaultValue: Ext4.Date.format(new Date(), 'Y-m-d 8:0')
             },
             Billable: {
                 defaultValue: 'Yes',


### PR DESCRIPTION
#### Rationale
Testing the ASB form in Safari, I was getting a JS error about not having a format() function on the Date object

#### Changes
* Switch to use the Ext4 function which we know will be available