### PR TITLE
21.7 fb compliance input screen fixes

### DIFF
--- a/ONPRC_EHR_ComplianceDB/resources/views/begin.html
+++ b/ONPRC_EHR_ComplianceDB/resources/views/begin.html
@@ -66,17 +66,15 @@ Ext4.onReady(function(){
                 name: 'View/Edit Allowable Locations', url: '<%=contextPath%>/query' + container + '/executeQuery.view?schemaName=ehr_compliancedb&query.queryName=EmployeeLocations'
             },{
                 name: 'View/Edit Allowable Unit Names', url: '<%=contextPath%>/query' + container + '/executeQuery.view?schemaName=ehr_compliancedb&query.queryName=Unit_Names'
-            }]
-        },{
-            header: 'Data Entry Forms',
-            items: [{
+            },{
                 name: 'Employee Per Unit/Category Form', url: LABKEY.ActionURL.buildURL('ehr','dataEntryForm', '/ONPRC/Admin/Compliance',{formType: 'employeeunitrecords'})
             },{
                 name: 'Requirements Per Essential Form', url: LABKEY.ActionURL.buildURL('ehr','dataEntryForm', '/ONPRC/Admin/Compliance',{formType: 'employeecategoryrecords'})
             },{
                 name: 'Edit form with Task ID', url: LABKEY.ActionURL.buildURL('ONPRC_EHR_ComplianceDB', 'enterData.view',(ctx ? ctx['EmployeeContainer'] : null), null)
             }]
-            },{
+        },{
+
         header: 'Printable Reports',
         items: [{
             name: 'Employees Summary Report', url: LABKEY.ActionURL.buildURL('ONPRC_EHR_ComplianceDB', 'printableComplianceReports', LABKEY.ActionURL.getContainer())

--- a/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeCategory.js
+++ b/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeCategory.js
@@ -12,12 +12,16 @@ EHR.model.DataModelManager.registerMetadata('EmployeeCategoryRecords', {
         'ehr_compliancedb.requirementspercategory': {
             requirementname: {
                 hidden: false,
-                anyMatch: true,
-                allowBlank: true,
+                allowBlank: false,
                 columnConfig: {
                     width: 350,
                     header: 'Requirement Name'
                 },
+                editorConfig: {
+                    caseSensitive: false,
+                    anyMatch: true
+                },
+
                 lookup: {
                     xtype: 'labkey-combo',
                     containerPath: '/ONPRC/Admin/Compliance',
@@ -36,12 +40,16 @@ EHR.model.DataModelManager.registerMetadata('EmployeeCategoryRecords', {
             },
             category: {
                 hidden: false,
-                anyMatch: true,
                 allowBlank: true,
                 columnConfig: {
                     width: 150,
                     header: 'Category'
                 },
+                editorConfig: {
+                    caseSensitive: false,
+                    anyMatch: true
+                },
+
                 lookup: {
                     xtype: 'labkey-combo',
                     containerPath: '/ONPRC/Admin/Compliance',
@@ -57,13 +65,17 @@ EHR.model.DataModelManager.registerMetadata('EmployeeCategoryRecords', {
             },
             unit: {
                 hidden: false,
-                anyMatch: true,
                 allowBlank: true,
                 hasOwnTpl: true,
                 columnConfig: {
                     width: 300,
                     header: 'Unit'
                 },
+                editorConfig: {
+                    caseSensitive: false,
+                    anyMatch: true
+                },
+
                 lookup: {
                     xtype: 'labkey-combo',
                     containerPath: '/ONPRC/Admin/Compliance',

--- a/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeUnit.js
+++ b/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeUnit.js
@@ -21,17 +21,16 @@ EHR.model.DataModelManager.registerMetadata('EmployeeRequiredUnit', {
                     xtype: 'labkey-combo',
                     containerPath: '/ONPRC/Admin/Compliance',
                     schema: 'ehr_compliancedb',
-                    queryName: 'Employeelist',
+                    queryName: 'Employees',
                     keyColumn: 'employeeid',
-                    // displayColumn: 'employeeid',
                     sort: 'employeeid',
-                    columns: 'employeeid,lastName,FirstName'
+                    columns: 'employeeid,lastName,firstName'
 
                 },
                 editorConfig: {
                     anyMatch: true,
                     listConfig: {
-                        innerTpl: '{[LABKEY.Utils.encodeHtml(values.employeeid + (values.LastName ? " (" + values.LastName + (values.FirstName ? ", " + values.FirstName : "") + ")" : ""))]}',
+                        innerTpl: '{[LABKEY.Utils.encodeHtml(values.employeeid + (values.lastName ? " (" + values.lastName + (values.firstName ? ", " + values.firstName : "") + ")" : ""))]}',
                         getInnerTpl: function(){
                             return this.innerTpl;
                         }

--- a/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeUnit.js
+++ b/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeUnit.js
@@ -12,8 +12,7 @@ EHR.model.DataModelManager.registerMetadata('EmployeeRequiredUnit', {
         'ehr_compliancedb.employeeperUnit': {
             employeeid: {
                 hidden: false,
-                anyMatch: true,
-                allowBlank: true,
+                allowBlank: false,
                 columnConfig: {
                     width: 350,
                     header: 'Employee ID'
@@ -41,13 +40,18 @@ EHR.model.DataModelManager.registerMetadata('EmployeeRequiredUnit', {
             },
             category: {
                 hidden: false,
-                anyMatch: true,
-                allowBlank: true,
+                allowBlank: false,
                 hasOwnTpl: true,
                 columnConfig: {
                     width: 300,
                     header: 'Category'
                 },
+
+                editorConfig: {
+                    caseSensitive: false,
+                    anyMatch: true
+                },
+
                 lookup: {
                     xtype: 'labkey-combo',
                     containerPath: '/ONPRC/Admin/Compliance',
@@ -65,13 +69,17 @@ EHR.model.DataModelManager.registerMetadata('EmployeeRequiredUnit', {
 
             unit: {
                 hidden: false,
-                anyMatch: true,
-                allowBlank: true,
+                allowBlank: false,
                 hasOwnTpl: true,
                 columnConfig: {
                     width: 300,
                     header: 'Unit'
                 },
+                editorConfig: {
+                    caseSensitive: false,
+                    anyMatch: true
+                },
+
                 lookup: {
                     xtype: 'labkey-combo',
                     containerPath: '/ONPRC/Admin/Compliance',

--- a/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeUnit.js
+++ b/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/model/sources/EmployeeUnit.js
@@ -39,7 +39,7 @@ EHR.model.DataModelManager.registerMetadata('EmployeeRequiredUnit', {
             },
             category: {
                 hidden: false,
-                allowBlank: false,
+                allowBlank: true,
                 hasOwnTpl: true,
                 columnConfig: {
                     width: 300,
@@ -68,7 +68,7 @@ EHR.model.DataModelManager.registerMetadata('EmployeeRequiredUnit', {
 
             unit: {
                 hidden: false,
-                allowBlank: false,
+                allowBlank: true,
                 hasOwnTpl: true,
                 columnConfig: {
                     width: 300,

--- a/ONPRC_EHR_ComplianceDB/src/org/labkey/ONPRCEHR_ComplianceDB/dataentry/EmployeeRequirementCategoryFormSection.java
+++ b/ONPRC_EHR_ComplianceDB/src/org/labkey/ONPRCEHR_ComplianceDB/dataentry/EmployeeRequirementCategoryFormSection.java
@@ -19,6 +19,9 @@ import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.dataentry.SimpleGridPanel;
 import org.labkey.api.view.template.ClientDependency;
 
+import java.util.ArrayList;
+import java.util.List;
+
 //import org.labkey.api.ehr.dataentry.SimpleFormSection;
 
 //Created: 10-4-2021  R.Blasa
@@ -39,6 +42,32 @@ public class EmployeeRequirementCategoryFormSection extends SimpleGridPanel
         addExtraProperty(BY_PASS_ANIMAL_ID, "true");
         addClientDependency(ClientDependency.supplierFromPath("EHR_ComplianceDB/model/sources/EmployeeCategoryClientStore.js"));
         setClientStoreClass("ONPRC_EHR.data.EmployeeCategoryClientStore");
+    }
+
+    @Override
+    public List<String> getTbarButtons()
+    {
+        List<String> defaultButtons = new ArrayList<>();
+        defaultButtons.addAll(super.getTbarButtons());
+
+        int idx = 0;
+        if (defaultButtons.contains("ADDANIMALS"))
+        {
+            idx = defaultButtons.indexOf("ADDANIMALS");
+            defaultButtons.remove("ADDANIMALS");
+        }
+
+        return defaultButtons;
+    }
+
+    @Override
+    public List<String> getTbarMoreActionButtons()
+    {
+        List<String> defaultButtons = super.getTbarMoreActionButtons();
+        defaultButtons.remove("GUESSPROJECT");
+        defaultButtons.remove("COPY_IDS");
+
+        return defaultButtons;
     }
 }
 

--- a/ONPRC_EHR_ComplianceDB/src/org/labkey/ONPRCEHR_ComplianceDB/dataentry/EmployeeRequirementUnitFormSection.java
+++ b/ONPRC_EHR_ComplianceDB/src/org/labkey/ONPRCEHR_ComplianceDB/dataentry/EmployeeRequirementUnitFormSection.java
@@ -19,6 +19,9 @@ import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.dataentry.SimpleFormSection;
 import org.labkey.api.view.template.ClientDependency;
 
+import java.util.ArrayList;
+import java.util.List;
+
 //Created: 7-6-2021  R.Blasa converting category to unit
 
 public class EmployeeRequirementUnitFormSection extends SimpleFormSection
@@ -37,6 +40,31 @@ public class EmployeeRequirementUnitFormSection extends SimpleFormSection
         addClientDependency(ClientDependency.supplierFromPath("EHR_ComplianceDB/model/sources/EmployeeUnitClientStore.js"));
         setClientStoreClass("ONPRC_EHR.data.EmployeeUnitClientStore");
 
+    }
+    @Override
+    public List<String> getTbarButtons()
+    {
+        List<String> defaultButtons = new ArrayList<>();
+        defaultButtons.addAll(super.getTbarButtons());
+
+        int idx = 0;
+        if (defaultButtons.contains("ADDANIMALS"))
+        {
+            idx = defaultButtons.indexOf("ADDANIMALS");
+            defaultButtons.remove("ADDANIMALS");
+        }
+
+        return defaultButtons;
+    }
+
+    @Override
+    public List<String> getTbarMoreActionButtons()
+    {
+        List<String> defaultButtons = super.getTbarMoreActionButtons();
+        defaultButtons.remove("GUESSPROJECT");
+        defaultButtons.remove("COPY_IDS");
+
+        return defaultButtons;
     }
 
 

--- a/ONPRC_EHR_ComplianceDB/src/org/labkey/ONPRCEHR_ComplianceDB/dataentry/EmployeeRequirementUnitFormType.java
+++ b/ONPRC_EHR_ComplianceDB/src/org/labkey/ONPRCEHR_ComplianceDB/dataentry/EmployeeRequirementUnitFormType.java
@@ -59,6 +59,7 @@ public class EmployeeRequirementUnitFormType extends  TaskForm
         return ret;
     };
 
+
     @Override
     protected boolean canInsert()
     {


### PR DESCRIPTION
#### Rationale

#### Related Pull Requests


#### Changes
Allowed input screens drop down listings to be selectable for any text string search.  Removed some tool bar buttons.  Removed some Tbar rmore actions menus.  Updated employee list controls to include all active and inactive employee items.
