### PR TITLE
Drop unused stored procedure that was created in "dbo" instead of "onprc_ehr"

### DIFF
--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-22.000-22.001.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-22.000-22.001.sql
@@ -1,0 +1,4 @@
+-- This stored procedure was incorrectly named and placed in the wrong schema when created in onprc_ehr-18.10-20.101.sql.
+-- It's also unused, so just drop it.
+IF EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND object_id = OBJECT_ID('[dbo].[onprc_ehr.etlStep1eIACUCtoPRIMEProcessing]'))
+    DROP PROCEDURE [dbo].[onprc_ehr.etlStep1eIACUCtoPRIMEProcessing]

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
@@ -121,7 +121,7 @@ public class ONPRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.202;
+        return 22.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This procedure is unused and the fact that it was created in `dbo` causes problems when attempting to re-install the `onprc_ehr` module