### PR TITLE
Remove unused <categories> elements from datasets_manifest.xml files in sample archives

### DIFF
--- a/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingController.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.onprc_billing;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -181,7 +182,7 @@ public class ONPRC_BillingController extends SpringActionController
         }
 
         @Override
-        public URLHelper getSuccessURL(QueryForm form)
+        public @NotNull URLHelper getSuccessURL(QueryForm form)
         {
             URLHelper url = form.getReturnURLHelper();
             return url != null ? url : QueryService.get().urlFor(getUser(), getContainer(), QueryAction.executeQuery, ONPRC_BillingSchema.NAME, ONPRC_BillingSchema.TABLE_INVOICE_RUNS);

--- a/onprc_ehr/resources/referenceStudy/study/datasets/datasets_manifest.xml
+++ b/onprc_ehr/resources/referenceStudy/study/datasets/datasets_manifest.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-    <categories>
-        <category>Behavior</category>
-        <category>ClinPath</category>
-        <category>Colony Management</category>
-        <category>Clinical</category>
-        <category>Pathology</category>
-    </categories>
     <datasets>
         <dataset name="antibioticSensitivity" id="5011" category="ClinPath" type="Standard">
             <tags/>

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
@@ -17,6 +17,7 @@ package org.labkey.onprc_ehr;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.MutatingApiAction;
@@ -355,7 +356,7 @@ public class ONPRC_EHRController extends SpringActionController
         }
 
         @Override
-        public ActionURL getSuccessURL(Object form)
+        public @NotNull ActionURL getSuccessURL(Object form)
         {
             return getContainer().getStartURL(getUser());
         }

--- a/sla/src/org/labkey/sla/SLAController.java
+++ b/sla/src/org/labkey/sla/SLAController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.sla;
 
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -130,7 +131,7 @@ public class SLAController extends SpringActionController
         }
 
         @Override
-        public ActionURL getSuccessURL(ValidateEtlSyncForm form)
+        public @NotNull ActionURL getSuccessURL(ValidateEtlSyncForm form)
         {
             return getContainer().getStartURL(getUser());
         }


### PR DESCRIPTION
#### Rationale
Support for unused `<categories>` element has been removed

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3062