### PR TITLE
Skip study import query validation

### DIFF
--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -115,6 +115,15 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         importFolderFromPath(1);
     }
 
+    // Validate queries at end of tests instead of during import
+    // TODO: Add linked schemas to tests
+    @Override
+    protected boolean shouldValidateQueries()
+    {
+        return true;
+    }
+
+    @Override
     protected boolean skipStudyImportQueryValidation()
     {
         return true;

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -115,6 +115,11 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         importFolderFromPath(1);
     }
 
+    protected boolean skipStudyImportQueryValidation()
+    {
+        return true;
+    }
+
     @Override
     protected void doExtraPreStudyImportSetup()
     {


### PR DESCRIPTION
#### Rationale
Several new linked schemas have been added in ONPRC modules, and the related queries updated to use those linked schemas.  For now, skip query validation on import until those linked schemas can be added to ONPRC test setup.  Instead do query validation at end of tests.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/378

#### Changes
* Set skipStudyImportQueryValidation to true
* Set shouldValidateQueries() to true
