### PR TITLE
Clean up query validation warnings. Mostly trailing commas

### DIFF
--- a/onprc_ehr/resources/queries/ehr_lookups/cageReview.sql
+++ b/onprc_ehr/resources/queries/ehr_lookups/cageReview.sql
@@ -40,7 +40,7 @@ SELECT
    t.heightStatus,
   t.weightExempt,
   t.totalWeightExempt,
-  t.totalHeightExempt,
+  t.totalHeightExempt
 
 FROM (
 

--- a/onprc_ehr/resources/queries/ehr_lookups/roomUtilization.sql
+++ b/onprc_ehr/resources/queries/ehr_lookups/roomUtilization.sql
@@ -11,7 +11,7 @@ SELECT
   count(DISTINCT h.cage) as CagesUsed,
   max(cbr.availableCages) - count(DISTINCT h.cage) - max(cbr.markedUnavailable) as CagesEmpty,
   round(((CAST(count(DISTINCT h.cage) as double) + max(cbr.markedUnavailable)) / cast(max(cbr.availableCages) as double)) * 100, 1) as pctUsed,
-  count(DISTINCT h.id) as TotalAnimals,
+  count(DISTINCT h.id) as TotalAnimals
 
 
 FROM ehr_lookups.rooms r


### PR DESCRIPTION
#### Rationale
These syntax warnings aren't causing any direct problems but they do clutter up the results of query validation

#### Changes
* Address warnings by trimming extraneous commas