### PR TITLE
Resume running query validation at beginning of test

### DIFF
--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -121,20 +121,6 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         importFolderFromPath(1);
     }
 
-    // Validate queries at end of tests instead of during import
-    // TODO: Add linked schemas to tests
-    @Override
-    protected boolean shouldValidateQueries()
-    {
-        return true;
-    }
-
-    @Override
-    protected boolean skipStudyImportQueryValidation()
-    {
-        return true;
-    }
-
     @Override
     protected void doExtraPreStudyImportSetup() throws IOException, CommandException
     {

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
@@ -184,22 +184,6 @@ public class ONPRC_BillingTest extends AbstractONPRC_EHRTest
         checker().verifyEquals("Adding new project was not successful", 1, projectTable.getDataRowCount());
     }
 
-
-    @Override
-    public void validateQueries(boolean validateSubfolders)
-    {
-        //NOTE: unlike other EHR tests, we skip query validation during study import and perform at the end
-        //On team city we kept hitting some sort of timing issue, potentially related to the timing/caching of dataset
-        //columns, which resulted in certain calculated columns not being present and queries failing during study import only
-        super.validateQueries(validateSubfolders);
-    }
-
-    @Override
-    protected boolean skipStudyImportQueryValidation()
-    {
-        return true;
-    }
-
     @Override
     protected void populateInitialData()
     {


### PR DESCRIPTION
#### Rationale
While we had known query validation failures, we pushed the check to the end of the test. That let us retain the coverage from the rest of the test, but meant that the tests behaved differently in the shared EHR suite (which are not configured on TeamCity to run validation at the end) and the more targeted ONPRC suite (which Trey configured to allow the validation at the end).

#### Changes
* Return to the original behavior - validate while setting up the tests