### PR TITLE
22.3 fb assigned vet fix

### DIFF
--- a/onprc_ehr/resources/queries/ehr_lookups/roomsAssignment.sql
+++ b/onprc_ehr/resources/queries/ehr_lookups/roomsAssignment.sql
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * 2022-08-23 Changed source of assignment data to linked schema
  */
 select
 

--- a/onprc_ehr/resources/queries/ehr_lookups/roomsAssignment.sql
+++ b/onprc_ehr/resources/queries/ehr_lookups/roomsAssignment.sql
@@ -34,7 +34,7 @@ select
   cast(a.project.name || ' (' || a.project.investigatorId.lastname || '): ' || cast(count(distinct a.id.curLocation.cage) as varchar) as varchar) as projectCageTotal,
   count(distinct a.id) as totalAnimals
 
-from study.assignment a
+from finance_Study.assignment a
 where a.isActive = true and a.id.curLocation.room IS NOT NULL
 group by a.id.curLocation.room, a.project.name, a.project.investigatorId.lastname
 

--- a/onprc_ehr/resources/queries/study/vet_assignmentDemographics.sql
+++ b/onprc_ehr/resources/queries/study/vet_assignmentDemographics.sql
@@ -146,6 +146,7 @@ LEFT JOIN (
 
 --report only on animals that are alive or deceased in last year
 where
+    dm.calculated_status = 'Alive' and
     (d2.date is Null or Cast(d2.date as varchar(20)) > d.MostRecentArrival or (d2.date >  TimeStampAdd('SQL_TSI_MONTH', -12,Now())))
   and (d.demographics.calculated_status is not null) --and
 -- d.id not Like '[A-Z]%'


### PR DESCRIPTION
#### Rationale
Clean up of file vet_assignmentDemographics to correct inaccurate reporting of liv animals without a Vet assigned

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
