### PR TITLE
Removed Manage Soap from Clinical Snapshot web pabe.

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/buttons/ClinicalActionsButton.js
+++ b/onprc_ehr/resources/web/onprc_ehr/buttons/ClinicalActionsButton.js
@@ -83,33 +83,7 @@ Ext4.define('onprc_ehr.buttons.ClinicalActionsButton', {
             }
         });
 
-        toAdd.push({
-            text: 'Enter SOAP',
-            disabled: !EHR.Security.hasClinicalEntryPermission() || !EHR.Security.hasPermission(EHR.QCStates.COMPLETED, 'update', [{schemaName: 'study', queryName: 'Clinical Remarks'}]),
-            tooltip: !EHR.Security.hasClinicalEntryPermission() || !EHR.Security.hasPermission(EHR.QCStates.COMPLETED, 'update', [{schemaName: 'study', queryName: 'Clinical Remarks'}]) ? 'You do not have permission for this action' : null,
-            scope: this,
-            handler: function(btn){
-                var animalId = this.getAnimalId();
-                if (!animalId){
-                    Ext4.Msg.alert('Error', 'No Animal Selected');
-                    return;
-                }
 
-                Ext4.create('EHR.window.ManageRecordWindow', {
-                    schemaName: 'study',
-                    queryName: 'clinRemarks',
-                    maxItemsPerCol: 11,
-                    pkCol: 'objectid',
-                    pkValue: LABKEY.Utils.generateUUID().toUpperCase(),
-                    extraMetaData: {
-                        Id: {
-                            defaultValue: animalId,
-                            editable: false
-                        }
-                    }
-                }).show();
-            }
-        });
 
         toAdd.push({
             text: 'Open Exam Form',

--- a/onprc_ehr/resources/web/onprc_ehr/buttons/ClinicalActionsButton.js
+++ b/onprc_ehr/resources/web/onprc_ehr/buttons/ClinicalActionsButton.js
@@ -84,7 +84,6 @@ Ext4.define('onprc_ehr.buttons.ClinicalActionsButton', {
         });
 
 
-
         toAdd.push({
             text: 'Open Exam Form',
             disabled: !EHR.Security.hasClinicalEntryPermission() || !EHR.Security.hasPermission(EHR.QCStates.IN_PROGRESS, 'insert', [{schemaName: 'study', queryName: 'Clinical Remarks'}]),

--- a/onprc_ehr/resources/web/onprc_ehr/model/sources/ClinicalReport.js
+++ b/onprc_ehr/resources/web/onprc_ehr/model/sources/ClinicalReport.js
@@ -36,6 +36,10 @@ EHR.model.DataModelManager.registerMetadata('ClinicalReport_ONPRC', {
                 },
                 height: 75
             },
+            hx: {
+                hidden: false,
+                header: 'Other Remark'
+            },
             CEG_Plan: {
                 formEditorConfig: {
                     xtype: 'onprc_ehr-CEG_Plantextarea'

--- a/onprc_ehr/resources/web/onprc_ehr/model/sources/ClinicalReport.js
+++ b/onprc_ehr/resources/web/onprc_ehr/model/sources/ClinicalReport.js
@@ -27,7 +27,7 @@ EHR.model.DataModelManager.registerMetadata('ClinicalReport_ONPRC', {
                 hidden: false,
                 allowBlank: false
             },
-            hx: {
+            remark: {
                 hidden: false
             },
             p2: {
@@ -36,7 +36,7 @@ EHR.model.DataModelManager.registerMetadata('ClinicalReport_ONPRC', {
                 },
                 height: 75
             },
-            hx: {
+            remark: {
                 hidden: false,
                 header: 'Other Remark'
             },


### PR DESCRIPTION
Removed "Manage Soap", and replace it with a single menu selection called "Open Exam Form.
