### PR TITLE
Add ONPRC parentage validation queries

### DIFF
--- a/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.query.xml
+++ b/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.query.xml
@@ -4,7 +4,7 @@
             <table tableName="parentsWrongGenderOrSpecies" tableDbType="NOT_IN_DB">
                 <tableTitle>Parentage Records With Mismatched Gender or Species</tableTitle>
                 <pkColumnName>lsid</pkColumnName>
-                 <updateUrl>/ehr/manageRecord.view?schemaName=study&amp;queryName=Parentage&amp;keyField=lsid&amp;key=${lsid}&amp;update=1</updateUrl>
+                 <updateUrl>/ehr/manageRecord.view?schemaName=study&amp;queryName=${queryName}&amp;keyField=lsid&amp;key=${lsid}&amp;update=1</updateUrl>
                 <columns>
                     <column columnName="Id">
 
@@ -16,6 +16,9 @@
                         <columnTitle>Parent Species</columnTitle>
                     </column>
                     <column columnName="lsid">
+                        <isHidden>true</isHidden>
+                    </column>
+                    <column columnName="queryName">
                         <isHidden>true</isHidden>
                     </column>
                 </columns>

--- a/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.query.xml
+++ b/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.query.xml
@@ -1,0 +1,25 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="parentsWrongGenderOrSpecies" tableDbType="NOT_IN_DB">
+                <tableTitle>Parentage Records With Mismatched Gender or Species</tableTitle>
+                <pkColumnName>lsid</pkColumnName>
+                 <updateUrl>/ehr/manageRecord.view?schemaName=study&amp;queryName=Parentage&amp;keyField=lsid&amp;key=${lsid}&amp;update=1</updateUrl>
+                <columns>
+                    <column columnName="Id">
+
+                    </column>
+                    <column columnName="parentGender">
+                        <columnTitle>Parent Gender</columnTitle>
+                    </column>
+                    <column columnName="parentSpecies">
+                        <columnTitle>Parent Species</columnTitle>
+                    </column>
+                    <column columnName="lsid">
+                        <isHidden>true</isHidden>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.sql
+++ b/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.sql
@@ -1,0 +1,18 @@
+SELECT
+    p.Id,
+    p.Id.demographics.species,
+    p.relationship,
+    p.parent,
+    p.parent.demographics.gender as parentGender,
+    p.parent.demographics.species as parentSpecies,
+    p.lsid
+FROM study.parentage p
+
+WHERE p.qcstate.publicdata = true AND (
+     -- Gender:
+    (p.parent.demographics.gender.origgender IS NOT NULL AND p.relationship = 'Sire' AND p.parent.demographics.gender.origgender != 'm') OR
+    (p.parent.demographics.gender.origgender IS NOT NULL AND p.relationship = 'Dam' AND p.parent.demographics.gender.origgender != 'f') OR
+
+    -- Species
+    (p.Id.demographics.species IS NOT NULL AND p.parent.demographics.species IS NOT NULL AND p.Id.demographics.species != p.parent.demographics.species)
+)

--- a/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.sql
+++ b/onprc_ehr/resources/queries/study/parentsWrongGenderOrSpecies.sql
@@ -1,18 +1,59 @@
 SELECT
     p.Id,
+    p.date,
     p.Id.demographics.species,
     p.relationship,
     p.parent,
     p.parent.demographics.gender as parentGender,
     p.parent.demographics.species as parentSpecies,
-    p.lsid
+    p.lsid,
+    'Parentage' as queryName
 FROM study.parentage p
 
 WHERE p.qcstate.publicdata = true AND (
      -- Gender:
     (p.parent.demographics.gender.origgender IS NOT NULL AND p.relationship = 'Sire' AND p.parent.demographics.gender.origgender != 'm') OR
     (p.parent.demographics.gender.origgender IS NOT NULL AND p.relationship = 'Dam' AND p.parent.demographics.gender.origgender != 'f') OR
+    (p.parent.demographics.gender.origgender IS NOT NULL AND p.relationship = 'Foster Dam' AND p.parent.demographics.gender.origgender != 'f') OR
 
     -- Species
     (p.Id.demographics.species IS NOT NULL AND p.parent.demographics.species IS NOT NULL AND p.Id.demographics.species != p.parent.demographics.species)
 )
+
+UNION ALL
+
+SELECT
+    p.Id,
+    p.date,
+    p.Id.demographics.species,
+    'dam' as relationship,
+    p.dam as parent,
+    d.gender as parentGender,
+    d.species as parentSpecies,
+    p.lsid,
+    'Birth' as queryName
+FROM study.birth p
+JOIN study.demographics d on (p.dam = d.Id)
+WHERE p.qcstate.publicdata = true AND (
+    (d.gender.origgender IS NOT NULL AND d.gender.origgender != 'f') OR
+    (p.Id.demographics.species IS NOT NULL AND d.species IS NOT NULL AND p.Id.demographics.species != d.species)
+) AND p.date >= '2000-01-01'
+
+UNION ALL
+
+SELECT
+    p.Id,
+    p.date,
+    p.Id.demographics.species,
+    'sire' as relationship,
+    p.sire as parent,
+    d.gender as parentGender,
+    d.species as parentSpecies,
+    p.lsid,
+    'Birth' as queryName
+FROM study.birth p
+JOIN study.demographics d on (p.sire = d.Id)
+WHERE p.qcstate.publicdata = true AND (
+    (d.gender.origgender IS NOT NULL AND d.gender.origgender != 'm') OR
+    (p.Id.demographics.species IS NOT NULL AND d.species IS NOT NULL AND p.Id.demographics.species != d.species)
+) AND p.date >= '2000-01-01'

--- a/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.query.xml
+++ b/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.query.xml
@@ -4,7 +4,7 @@
             <table tableName="parentsYoungerThanOffspring" tableDbType="NOT_IN_DB">
                 <tableTitle>Parentage Records With Parents Younger Than Offspring</tableTitle>
                 <pkColumnName>lsid</pkColumnName>
-                <updateUrl>/ehr/manageRecord.view?schemaName=study&amp;queryName=Parentage&amp;keyField=lsid&amp;key=${lsid}&amp;update=1</updateUrl>
+                <updateUrl>/ehr/manageRecord.view?schemaName=study&amp;queryName=${queryName}&amp;keyField=lsid&amp;key=${lsid}&amp;update=1</updateUrl>
                 <columns>
                     <column columnName="Id">
 
@@ -13,6 +13,9 @@
                         <columnTitle>Parent Birth</columnTitle>
                     </column>
                     <column columnName="lsid">
+                        <isHidden>true</isHidden>
+                    </column>
+                    <column columnName="queryName">
                         <isHidden>true</isHidden>
                     </column>
                 </columns>

--- a/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.query.xml
+++ b/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.query.xml
@@ -1,0 +1,22 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="parentsYoungerThanOffspring" tableDbType="NOT_IN_DB">
+                <tableTitle>Parentage Records With Parents Younger Than Offspring</tableTitle>
+                <pkColumnName>lsid</pkColumnName>
+                <updateUrl>/ehr/manageRecord.view?schemaName=study&amp;queryName=Parentage&amp;keyField=lsid&amp;key=${lsid}&amp;update=1</updateUrl>
+                <columns>
+                    <column columnName="Id">
+
+                    </column>
+                    <column columnName="parentBirth">
+                        <columnTitle>Parent Birth</columnTitle>
+                    </column>
+                    <column columnName="lsid">
+                        <isHidden>true</isHidden>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.sql
+++ b/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.sql
@@ -1,0 +1,13 @@
+SELECT
+    p.Id,
+    p.parent,
+    p.relationship,
+    p.method,
+    p.Id.demographics.birth,
+    p.parent.demographics.birth as parentBirth,
+    p.lsid
+
+FROM study.parentage p
+WHERE
+    p.qcstate.publicdata = true AND
+    (p.Id.demographics.birth IS NOT NULL AND p.parent.demographics.birth IS NOT NULL AND p.Id.demographics.birth <= p.parent.demographics.birth)

--- a/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.sql
+++ b/onprc_ehr/resources/queries/study/parentsYoungerThanOffspring.sql
@@ -5,9 +5,46 @@ SELECT
     p.method,
     p.Id.demographics.birth,
     p.parent.demographics.birth as parentBirth,
-    p.lsid
+    p.lsid,
+    'Parentage' as queryName
 
 FROM study.parentage p
 WHERE
     p.qcstate.publicdata = true AND
     (p.Id.demographics.birth IS NOT NULL AND p.parent.demographics.birth IS NOT NULL AND p.Id.demographics.birth <= p.parent.demographics.birth)
+
+UNION ALL
+
+SELECT
+    p.Id,
+    p.dam as parent,
+    'Dam' as relationship,
+    'Observed' as method,
+    p.Id.demographics.birth,
+    d.birth as parentBirth,
+    p.lsid,
+    'Birth' as queryName
+
+FROM study.birth p
+JOIN study.demographics d on (p.dam = d.Id)
+WHERE
+    p.qcstate.publicdata = true AND
+    (p.Id.demographics.birth IS NOT NULL AND d.birth IS NOT NULL AND p.Id.demographics.birth <= d.birth)
+
+UNION ALL
+
+SELECT
+    p.Id,
+    p.sire as parent,
+    'Sire' as relationship,
+    'Observed' as method,
+    p.Id.demographics.birth,
+    d.birth as parentBirth,
+    p.lsid,
+    'Birth' as queryName
+
+FROM study.birth p
+JOIN study.demographics d on (p.sire = d.Id)
+WHERE
+    p.qcstate.publicdata = true AND
+    (p.Id.demographics.birth IS NOT NULL AND d.birth IS NOT NULL AND p.Id.demographics.birth <= d.birth)

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyAlertsNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyAlertsNotification.java
@@ -773,6 +773,27 @@ public class ColonyAlertsNotification extends AbstractEHRNotification
         }
     }
 
+    protected void pedigreeIssues(final Container c, User u, final StringBuilder msg)
+    {
+        TableSelector ts = new TableSelector(getStudySchema(c, u).getTable("parentage"), Collections.singleton(getStudy(c).getSubjectColumnName()));
+        long count = ts.getRowCount();
+        if (count > 0)
+        {
+            msg.append("<b>WARNING: There are " + count + " parentage records that are younger than their offspring.</b><br>\n");
+            msg.append("<p><a href='" + getExecuteQueryUrl(c, "study", "parentsYoungerThanOffspring", null) + "'>Click here to view them</a><br>\n\n");
+            msg.append("<hr>\n\n");
+        }
+
+        ts = new TableSelector(getStudySchema(c, u).getTable("parentsWrongGenderOrSpecies"), Collections.singleton(getStudy(c).getSubjectColumnName()));
+        count = ts.getRowCount();
+        if (count > 0)
+        {
+            msg.append("<b>WARNING: There are " + count + " parentage records listed with the wrong gender or species.</b><br>\n");
+            msg.append("<p><a href='" + getExecuteQueryUrl(c, "study", "parentsWrongGenderOrSpecies", null) + "'>Click here to view them</a><br>\n\n");
+            msg.append("<hr>\n\n");
+        }
+    }
+
     protected void incompleteBirthRecords(final Container c, User u, final StringBuilder msg)
     {
         SimpleFilter filter = new SimpleFilter(new SimpleFilter.OrClause(

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyMgmtNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyMgmtNotification.java
@@ -82,6 +82,7 @@ public class ColonyMgmtNotification extends ColonyAlertsNotification
         offspringWithMother(c, u, msg, 250);
         offspringWithMother(c, u, msg, 365);
         incompleteBirthRecords(c, u, msg);
+        pedigreeIssues(c, u, msg);
 
         //only send if there are alerts
         if (msg.length() > 0)


### PR DESCRIPTION
@labkey-jeckels @labkey-martyp and @jryurkanin: in EHR you recently added some parentage validation queries: https://github.com/LabKey/ehrModules/pull/534. That's all great, and it's probably not worth changing those at this point. Proper functioning of the EHR depends on having really accurate data, so these queries do matter a lot, and it's a great idea to continually add new ones as you encounter data issues. I made a comment to this effect on that PR, but there's two things here you might want to check out:

Note, in the ONPRC EHR parentage data is stored in a dataset called parentage, while in the default EHR demographics is used. Therefore the queries I'm adding here differ for this reason, but the points I'm making below apply to EHR too.

1) The first suggestion is that when running the query, it's helpful if you can give the user a way to easily rectify whatever problem exists. In the two queries here, you'll see that I set the updateURL to point to the underlying dataset. This way the user can load this SQL query, but LK will give them an edit button update the appropriate record, making things easier for the user.

2) Because ONPRC overrides the main EHR page I'm not really going to push this point all that strongly, but I dont see the point of adding the new basic HTML page (dataValidationReport.html), and especially not making it a top-level feature. There isnt anything wrong with having a report to load per se. The reason I bring this up is b/c there is already a way more functional system within EHR through the notification system (see subclasses of AbstractEHRNotification). Most concrete notifications are implemented in ONPRC_EHR, with ColonyAlertsNotification being one example. The very important difference with these is that: a) the notification runs automatically on a schedule, b) users can subscribe to it, and c) it reports problems when and if they exist automatically. In general, if all the validations pass, no email is sent. It's a very popular and efficient way to manage data validation. It is simply a lot more useful and reliable to make it automatic, as opposed to relying on a busy person to load and review some kind of HTML report regularly. These notifications can be executed through the browser on-demand as well (see example URL here: https://github.com/LabKey/onprcEHRModules/blob/3f288b6e328414f10da5a0e030e072669edf4b70/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java#L320), so it's not mutually exclusive with being run in the background and being run through the browser. 

Anyway, that's all I'll say on this point.