### PR TITLE
Remove unused imports

### DIFF
--- a/ogasync/src/org/labkey/ogasync/OGASyncManager.java
+++ b/ogasync/src/org/labkey/ogasync/OGASyncManager.java
@@ -16,8 +16,8 @@
 
 package org.labkey.ogasync;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
@@ -30,20 +30,13 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.util.JobRunner;
 import org.quartz.CronScheduleBuilder;
-import org.quartz.DailyTimeIntervalScheduleBuilder;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
-import org.quartz.TimeOfDay;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
 
-import java.io.IOException;
 import java.util.Date;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 public class OGASyncManager
 {


### PR DESCRIPTION
#### Rationale
No functional change; just removing the last reference to `DailyTimeIntervalScheduleBuilder`.
