### PR TITLE
Wait longer for ID field and improve error message

### DIFF
--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
@@ -36,7 +36,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.EHR;
@@ -58,7 +57,6 @@ import org.labkey.test.util.ext4cmp.Ext4GridRef;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.File;
 import java.io.IOException;
@@ -996,7 +994,8 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
 
         // NOTE: we have had problems w/ the ID field value not sticking.  i think it might have to do with the timing of server-side validation,
         //
-        waitFor(() -> MORE_ANIMAL_IDS[0].equals(Locator.tag("div").withLabel("Id:").findElement(getDriver()).getText()), "Id field not set", 1_000);
+        WebElement idDisplay = Locator.tag("div").withLabel("Id:").findElement(getDriver());
+        waitFor(() -> MORE_ANIMAL_IDS[0].equals(idDisplay.getText()), () -> "Id field not set: " + idDisplay.getText(), 5_000);
 
         //observations section
         waitAndClick(Ext4Helper.Locators.ext4Tab("Observations"));


### PR DESCRIPTION
#### Rationale
This test is failing intermittently:
```
org.openqa.selenium.TimeoutException: Id field not set <1.000s>
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2214)
  at app//org.labkey.test.WebDriverWrapper.waitFor(WebDriverWrapper.java:2207)
  at app//org.labkey.test.tests.onprc_ehr.ONPRC_EHRTest.testExamEntry(ONPRC_EHRTest.java:999)
```

#### Changes
* Increase wait for ID to be validated and populate form
