### PR TITLE
Use non-deprecated JSON-related method and interface names

### DIFF
--- a/sla/src/org/labkey/sla/model/PurchaseForm.java
+++ b/sla/src/org/labkey/sla/model/PurchaseForm.java
@@ -2,7 +2,7 @@ package org.labkey.sla.model;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.labkey.api.action.NewCustomApiForm;
+import org.labkey.api.action.ApiJsonForm;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JsonUtil;
 
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class PurchaseForm implements NewCustomApiForm
+public class PurchaseForm implements ApiJsonForm
 {
     private Integer _rowid;
     private String _objectid;


### PR DESCRIPTION
#### Rationale
`getNewJsonObject()` and `NewCustomApiForm` have replacements with better names