### PR TITLE
Support for restricted issue lists

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
@@ -21,7 +21,6 @@ import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.buttons.ChangeQCStateButton;
 import org.labkey.api.ehr.buttons.CreateTaskFromIdsButton;
 import org.labkey.api.ehr.buttons.CreateTaskFromRecordsButton;
-import org.labkey.onprc_ehr.buttons.CreateTaskFromRecordButtons;
 import org.labkey.api.ehr.buttons.DiscardTaskButton;
 import org.labkey.api.ehr.buttons.EHRShowEditUIButton;
 import org.labkey.api.ehr.buttons.MarkCompletedButton;
@@ -31,6 +30,7 @@ import org.labkey.api.ehr.dataentry.SingleQueryFormProvider;
 import org.labkey.api.ehr.demographics.ActiveFlagsDemographicsProvider;
 import org.labkey.api.ehr.security.EHRDataAdminPermission;
 import org.labkey.api.ehr.security.EHRProjectEditPermission;
+import org.labkey.api.issues.IssuesListDefService;
 import org.labkey.api.ldk.ExtendedSimpleModule;
 import org.labkey.api.ldk.buttons.ShowEditUIButton;
 import org.labkey.api.ldk.notification.NotificationService;
@@ -56,6 +56,7 @@ import org.labkey.onprc_ehr.buttons.BulkEditRequestsButton;
 import org.labkey.onprc_ehr.buttons.ChangeProjectedReleaseDateButton;
 import org.labkey.onprc_ehr.buttons.CreateNecropsyRequestButton;
 import org.labkey.onprc_ehr.buttons.CreateProjectButton;
+import org.labkey.onprc_ehr.buttons.CreateTaskFromRecordButtons;
 import org.labkey.onprc_ehr.buttons.HousingTransferButton;
 import org.labkey.onprc_ehr.buttons.ManageFlagsButton;
 import org.labkey.onprc_ehr.buttons.ProtocolEditButton;
@@ -83,18 +84,18 @@ import org.labkey.onprc_ehr.history.DefaultAnimalGroupsDataSource;
 import org.labkey.onprc_ehr.history.DefaultAnimalGroupsEndDataSource;
 import org.labkey.onprc_ehr.history.DefaultAnimalRecordFlagDataSource;
 import org.labkey.onprc_ehr.history.DefaultNHPTrainingDataSource;
-import org.labkey.onprc_ehr.history.DefaultSustainedReleaseDatasource;
 import org.labkey.onprc_ehr.history.DefaultSnomedDataSource;
+import org.labkey.onprc_ehr.history.DefaultSustainedReleaseDatasource;
 import org.labkey.onprc_ehr.history.ONPRCClinicalRemarksDataSource;
+import org.labkey.onprc_ehr.history.ONPRCEpocLabworkType;
 import org.labkey.onprc_ehr.history.ONPRCUrinalysisLabworkType;
 import org.labkey.onprc_ehr.history.ONPRCiStatLabworkType;
-import org.labkey.onprc_ehr.history.ONPRCEpocLabworkType;
+import org.labkey.onprc_ehr.issues.RestrictedIssueProviderImpl;
 import org.labkey.onprc_ehr.notification.*;
 import org.labkey.onprc_ehr.security.ONPRC_EHRCMUAdministrationPermission;
 import org.labkey.onprc_ehr.security.ONPRC_EHRCMUAdministrationRole;
 import org.labkey.onprc_ehr.security.ONPRC_EHRCustomerEditPermission;
 import org.labkey.onprc_ehr.security.ONPRC_EHRCustomerEditRole;
-//import org.labkey.onprc_ehr.security.ONPRC_EHRPMICEditRole;
 import org.labkey.onprc_ehr.security.ONPRC_EHRTransferRequestRole;
 import org.labkey.onprc_ehr.table.ONPRC_EHRCustomizer;
 
@@ -142,6 +143,9 @@ public class ONPRC_EHRModule extends ExtendedSimpleModule
 
 //        Added: 12-5-2019
 //        RoleManager.registerRole(new ONPRC_EHRPMICEditRole());
+
+        // register the permissions provider for a restricted issue list
+        IssuesListDefService.get().registerRestrictedIssueProvider(new RestrictedIssueProviderImpl());
     }
 
     @Override

--- a/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
@@ -1,0 +1,44 @@
+package org.labkey.onprc_ehr.issues;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.issues.Issue;
+import org.labkey.api.issues.RestrictedIssueProvider;
+import org.labkey.api.security.Group;
+import org.labkey.api.security.User;
+import org.labkey.api.security.ValidEmail;
+import org.labkey.api.util.Pair;
+
+import java.util.List;
+import java.util.Objects;
+
+public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
+{
+    @Override
+    public boolean hasPermission(Container c, User user, @NotNull Issue issue, @Nullable Group groupWithAccess)
+    {
+        // Site admins always have access
+        if (user.isInSiteAdminGroup())
+            return true;
+
+        // Assigned to users have access
+        if (Objects.equals(issue.getAssignedTo(), user.getUserId()))
+            return true;
+
+        // anyone on the notify list
+        List<Pair<User, ValidEmail>> notifyUsers = issue.getNotifyListUserEmail();
+        for (Pair<User, ValidEmail> nu : notifyUsers)
+        {
+            if (user.equals(nu.getKey()))
+                return true;
+        }
+
+        // if there is an option group configured, members will have access
+        if (groupWithAccess != null)
+        {
+            return user.isInGroup(groupWithAccess.getUserId());
+        }
+        return false;
+    }
+}

--- a/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
@@ -81,7 +81,7 @@ public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
     public boolean hasPermission(User user, @NotNull Issue issue, List<Issue> relatedIssues, List<ValidationError> errors)
     {
         // Site admins always have access
-        if (user.isInSiteAdminGroup())
+        if (user.hasSiteAdminPermission())
             return true;
 
         Container issueContainer = ContainerManager.getForId(issue.getContainerId());
@@ -132,5 +132,15 @@ public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
             return user.isInGroup(groupWithAccess.getUserId());
         }
         return false;
+    }
+
+    @Override
+    public void deleteProperties(Container c, String issueDefName)
+    {
+        PropertyManager.PropertyMap properties = PropertyManager.getProperties(c, getPropMapName(issueDefName));
+        if (!properties.isEmpty())
+        {
+            properties.delete();
+        }
     }
 }

--- a/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
@@ -80,6 +80,10 @@ public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
     @Override
     public boolean hasPermission(User user, @NotNull Issue issue, List<Issue> relatedIssues, List<ValidationError> errors)
     {
+        // Site admins always have access
+        if (user.isInSiteAdminGroup())
+            return true;
+
         Container issueContainer = ContainerManager.getForId(issue.getContainerId());
         if (issueContainer != null && isRestrictedIssueTracker(issueContainer, issue.getIssueDefName()))
         {
@@ -110,10 +114,6 @@ public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
 
     private boolean checkAccess(User user, @NotNull Issue issue, @Nullable Group groupWithAccess)
     {
-        // Site admins always have access
-        if (user.isInSiteAdminGroup())
-            return true;
-
         // Assigned to users have access
         if (Objects.equals(issue.getAssignedTo(), user.getUserId()))
             return true;

--- a/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
@@ -3,9 +3,14 @@ package org.labkey.onprc_ehr.issues;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.PropertyManager;
 import org.labkey.api.issues.Issue;
 import org.labkey.api.issues.RestrictedIssueProvider;
+import org.labkey.api.query.SimpleValidationError;
+import org.labkey.api.query.ValidationError;
 import org.labkey.api.security.Group;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.util.Pair;
@@ -15,8 +20,95 @@ import java.util.Objects;
 
 public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
 {
+    private static final String CAT_RESTRICTED_ISSUE_DEF_PROPERTIES = "RestrictedIssueDefProperties-";
+    private static final String PROP_RESTRICTED_ISSUE_LIST = "issueRestrictedIssueList";
+    private static final String PROP_RESTRICTED_ISSUE_LIST_GROUP = "issueRestrictedIssueListGroup";
+
     @Override
-    public boolean hasPermission(Container c, User user, @NotNull Issue issue, @Nullable Group groupWithAccess)
+    public void setRestrictedIssueTracker(Container c, String issueDefName, Boolean isRestricted)
+    {
+        setPropertyValue(c, issueDefName, PROP_RESTRICTED_ISSUE_LIST, String.valueOf(isRestricted));
+    }
+
+    @Override
+    public boolean isRestrictedIssueTracker(Container c, String issueDefName)
+    {
+        String value = getPropertyValue(c, issueDefName, PROP_RESTRICTED_ISSUE_LIST);
+        if (value != null)
+        {
+            return Boolean.parseBoolean(value);
+        }
+        return false;
+    }
+
+    @Override
+    public void setRestrictedIssueListGroup(Container c, String issueDefName, @Nullable Group group)
+    {
+        setPropertyValue(c, issueDefName, PROP_RESTRICTED_ISSUE_LIST_GROUP, null != group ? String.valueOf(group.getUserId()) : "0");
+    }
+
+    @Override
+    public @Nullable Group getRestrictedIssueListGroup(Container c, String issueDefName)
+    {
+        String groupId = getPropertyValue(c, issueDefName, PROP_RESTRICTED_ISSUE_LIST_GROUP);
+        if (null == groupId)
+            return null;
+
+        return SecurityManager.getGroup(Integer.valueOf(groupId));
+    }
+
+    private void setPropertyValue(Container c, String issueDefName, String key, String value)
+    {
+        PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(c, getPropMapName(issueDefName), true);
+        props.put(key, value);
+        props.save();
+    }
+
+    private String getPropertyValue(Container c, String issueDefName, String key)
+    {
+        return PropertyManager.getProperties(c, getPropMapName(issueDefName)).get(key);
+    }
+
+    private String getPropMapName(String issueDefName)
+    {
+        if (issueDefName == null)
+            throw new IllegalArgumentException("Issue def name must be specified");
+
+        return CAT_RESTRICTED_ISSUE_DEF_PROPERTIES + issueDefName;
+    }
+
+    @Override
+    public boolean hasPermission(User user, @NotNull Issue issue, List<Issue> relatedIssues, List<ValidationError> errors)
+    {
+        Container issueContainer = ContainerManager.getForId(issue.getContainerId());
+        if (issueContainer != null && isRestrictedIssueTracker(issueContainer, issue.getIssueDefName()))
+        {
+            Group group = getRestrictedIssueListGroup(issueContainer, issue.getIssueDefName());
+            if (!checkAccess(user, issue, group))
+            {
+                errors.add(new SimpleValidationError("This issue is in a restricted issue list. You do not have access to this issue"));
+                return false;
+            }
+        }
+
+        // the user must also have access to all related issues
+        for (Issue related : relatedIssues)
+        {
+            Container relatedContainer = ContainerManager.getForId(related.getContainerId());
+            if (relatedContainer != null && isRestrictedIssueTracker(relatedContainer, related.getIssueDefName()))
+            {
+                Group relatedGroup = getRestrictedIssueListGroup(relatedContainer, related.getIssueDefName());
+                if (!checkAccess(user, related, relatedGroup))
+                {
+                    errors.add(new SimpleValidationError(String.format("A related issue : %d is in a restricted issue list. You do not have access to that issue", related.getIssueId())));
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean checkAccess(User user, @NotNull Issue issue, @Nullable Group groupWithAccess)
     {
         // Site admins always have access
         if (user.isInSiteAdminGroup())


### PR DESCRIPTION
#### Rationale
To support a client request for restricted issue lists we will introduce changes to enable the configuration on a per issue list basis. Restricted issue lists will have the ability to limit access to individual issues at the point at which a user tries to access an issue to:
- view details
- update
- resolve, close, reopen

The feature will not filter access from the issue list view nor will it prevent access of any tables in the query schema. 

Access checking, and storage of admin UI settings is delegated to a new interface `RestrictedIssueProvider` which will need to be registered by the module providing the implementation.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1177
- https://github.com/LabKey/platform/pull/4329

#### Changes
- implement and register a `RestrictedIssueProvider` instance.