### PR TITLE
Strict SQL Fragment Update

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyAlertsNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyAlertsNotification.java
@@ -1596,7 +1596,6 @@ public class ColonyAlertsNotification extends AbstractEHRNotification
         SQLFragment sql = ti.getFromSQL("hc");
         Map<String, Object> params = new HashMap<>();
         params.put("MINDATE", cal.getTime());
-        QueryService.get().bindNamedParameters(sql, params);
         sql = new SQLFragment("SELECT * FROM ").append(sql);
         QueryService.get().bindNamedParameters(sql, params);
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyAlertsNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ColonyAlertsNotification.java
@@ -22,7 +22,6 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerFilterable;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.ResultsImpl;
@@ -1591,12 +1590,14 @@ public class ColonyAlertsNotification extends AbstractEHRNotification
         QueryDefinition qd = us.getQueryDefForTable("HousingCheck");
         List<QueryException> errors = new ArrayList<>();
         TableInfo ti = qd.getTable(us, errors, true);
+        if (null == ti)
+            return;
 
         SQLFragment sql = ti.getFromSQL("hc");
         Map<String, Object> params = new HashMap<>();
         params.put("MINDATE", cal.getTime());
         QueryService.get().bindNamedParameters(sql, params);
-        sql = new SQLFragment("SELECT * FROM " + sql.getSQL(), sql.getParams());
+        sql = new SQLFragment("SELECT * FROM ").append(sql);
         QueryService.get().bindNamedParameters(sql, params);
 
         SqlSelector ss = new SqlSelector(ti.getSchema(), sql);
@@ -1604,14 +1605,14 @@ public class ColonyAlertsNotification extends AbstractEHRNotification
 
         if (total > 0)
         {
-            msg.append("<b>WARNING: There are " + total + " housing records since " + getDateFormat(c).format(cal.getTime()) + " that do not have a contiguous previous or next record.</b><br>\n");
-            msg.append("<p><a href='" + getExecuteQueryUrl(c, "study", "HousingCheck", null) + "&query.param.MINDATE=" + getDateFormat(c).format(cal.getTime()) + "'>Click here to view them</a><br>\n\n");
+            msg.append("<b>WARNING: There are ").append(total).append(" housing records since ").append(getDateFormat(c).format(cal.getTime())).append(" that do not have a contiguous previous or next record.</b><br>\n");
+            msg.append("<p><a href='").append(getExecuteQueryUrl(c, "study", "HousingCheck", null)).append("&query.param.MINDATE=").append(getDateFormat(c).format(cal.getTime())).append("'>Click here to view them</a><br>\n\n");
             msg.append("<hr>\n\n");
         }
     }
 
     /**
-     * we find open ended problems where the animal is not alive
+     * we find open-ended problems where the animal is not alive
      */
     protected void deadAnimalsWithActiveProblems(final Container c, User u, final StringBuilder msg)
     {
@@ -1664,20 +1665,21 @@ public class ColonyAlertsNotification extends AbstractEHRNotification
         QueryDefinition qd = us.getQueryDefForTable("cageReview");
         List<QueryException> errors = new ArrayList<>();
         TableInfo ti = qd.getTable(us, errors, true);
+        if (null == ti)
+            return;
+
         SQLFragment sql = ti.getFromSQL("t");
         Map<String, Object> params = new HashMap<>();
         params.put("RequirementSet", requirementSet);
         QueryService.get().bindNamedParameters(sql, params);
 
-        List<Object> newParams = new ArrayList<>(sql.getParams());
-        newParams.add(filterTerm);
-        sql = new SQLFragment("SELECT * FROM " + sql.getSQL() + " WHERE t.status = ?", newParams);
+        sql = new SQLFragment("SELECT * FROM ").append(sql).append(" WHERE t.status = ?").add(filterTerm);
         SqlSelector ss = new SqlSelector(ti.getSchema(), sql);
-        Map<String, Object>[] rows = ss.getArray(Map.class);
+        Map<String, Object>[] rows = ss.getMapArray();
 
         if (rows.length > 0)
         {
-            msg.append("<b>" + message + "</b><br>");
+            msg.append("<b>").append(message).append("</b><br>");
             for (Map<String, Object> row : rows)
             {
                 String room = (String)row.get("room");
@@ -1694,8 +1696,7 @@ public class ColonyAlertsNotification extends AbstractEHRNotification
                     if (cage != null)
                         msg.append(" ").append(cage);
 
-                        msg.append(": ").append(sqFtStatus);
-
+                    msg.append(": ").append(sqFtStatus);
                     msg.append("<br>");
                 }
 


### PR DESCRIPTION
#### Rationale
Related PRs enforce stricter SQL fragment syntax. The current implementation of a couple notification SQL queries bring in SQL file comments in the SQL Fragment creation which fails some asserts. Update these to append the SQL files after fragment creation.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4416
* https://github.com/LabKey/platform/pull/4394

#### Changes
* Update SQL fragment creation
* Update some string builder appends and null checks
