### PR TITLE
Switch out deprecated method and deprecated constant

### DIFF
--- a/sla/src/org/labkey/sla/etl/ETLRunnable.java
+++ b/sla/src/org/labkey/sla/etl/ETLRunnable.java
@@ -15,12 +15,10 @@
  */
 package org.labkey.sla.etl;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -47,14 +45,15 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
-import org.labkey.api.resource.FileResource;
 import org.labkey.api.resource.DirectoryResource;
+import org.labkey.api.resource.FileResource;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.study.DatasetTable;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -929,7 +928,7 @@ public class ETLRunnable implements Runnable
             FileResource f = (FileResource)sqlFile;
 
             if (!f.getName().endsWith("sql")) continue;
-            String sql = Files.toString(f.getFile(), Charsets.UTF_8);
+            String sql = PageFlowUtil.getFileContentsAsString(f.getFile());
             String key = f.getName().substring(0, f.getName().indexOf('.'));
             qMap.put(key, sql);
         }


### PR DESCRIPTION
#### Rationale
Use standard method instead of deprecated stuff
