### PR TITLE
Temp fix for ETL and troubleshooting

### DIFF
--- a/onprc_ehr/resources/scripts/onprc_ehr/etl.js
+++ b/onprc_ehr/resources/scripts/onprc_ehr/etl.js
@@ -33,7 +33,21 @@ EHR.ETL = {
         if(EHR.ETL.byQuery[helper.getQueryName()])
             EHR.ETL.byQuery[helper.getQueryName()](row, errors);
 
-        helper.logDebugMsg('Repaired: '+row);
+        try {
+            helper.logDebugMsg('Repaired: ' + row);
+        }
+        catch(e) {
+            console.log('logDebugMsg failed');
+            console.log(e);
+            var i = 0;
+            for (var property in row) {
+                if (row.hasOwnProperty(property)) {
+                    console.log('prop: ', property, ', value: ', row[property]);
+                }
+                i++;
+            }
+            console.log('prop count:', i);
+        }
     },
 
     fixParticipantId: function (row, errors){

--- a/onprc_ehr/resources/scripts/onprc_ehr/etl.js
+++ b/onprc_ehr/resources/scripts/onprc_ehr/etl.js
@@ -47,6 +47,7 @@ EHR.ETL = {
                 i++;
             }
             console.log('prop count:', i);
+            console.log('errors:', errors);
         }
     },
 


### PR DESCRIPTION
#### Rationale
An issue calling row.toString() in log messages is throwing an error in a couple ONPRC ETLs. For troubleshooting and getting this high priority ETL working, swallow the exception and print extra logging when it fails.

#### Changes
* Catch exception on row.toString()
* Log troubleshooting info
