### PR TITLE
Fix flaky ONPRC_BillingTest problem where project title is getting lost during insert

### DIFF
--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
@@ -158,7 +158,10 @@ public class ONPRC_BillingTest extends AbstractONPRC_EHRTest
         protocolTable.clickHeaderMenu("More Actions", false, "Edit Records");
         protocolTable.clickImportBulkData();
 
+        // HACK
+        Thread.sleep(2500);
         setFormElement(Locator.textarea("title"), protocolTitle);
+        Thread.sleep(2500);
         clickButton("Submit");
 
         assertTextPresent(protocolTitle);

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
@@ -161,6 +161,7 @@ public class ONPRC_BillingTest extends AbstractONPRC_EHRTest
         setFormElement(Locator.textarea("title"), protocolTitle);
         clickButton("Submit");
 
+        assertTextPresent(protocolTitle);
         protocolTable.setFilter("title", "Equals", protocolTitle);
         String protocolId = protocolTable.getDataAsText(0, "protocol");
 


### PR DESCRIPTION
#### Rationale
This test is failing pretty regularly in 23.3. It's a timing problem. The test is trying to set the Title value but it's not getting persisted in the row.

I hate adding sleeps but we need to get this test passing as it's a gating check for this repo. I'd be delighted to switch to a more targeted fix if people have ideas.

#### Changes
* Slow down a bit to ensure the form is fully initialized and the value sticks