### PR TITLE
Ticket 48396: Update flags trigger override

### DIFF
--- a/onprc_ehr/resources/scripts/onprc_ehr/onprc_triggers.js
+++ b/onprc_ehr/resources/scripts/onprc_ehr/onprc_triggers.js
@@ -464,7 +464,9 @@ exports.init = function(EHR){
 
     EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'study', 'flags', function(event, helper){
         helper.setScriptOptions({
-            allowFutureDates: true
+            allowFutureDates: true,
+            removeTimeFromDate: true,
+            removeTimeFromEndDate: true
         });
 
         EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'flags', EHR.Server.TriggerManager.Events.AFTER_INSERT);

--- a/onprc_ehr/resources/scripts/onprc_ehr/onprc_triggers.js
+++ b/onprc_ehr/resources/scripts/onprc_ehr/onprc_triggers.js
@@ -462,6 +462,14 @@ exports.init = function(EHR){
 
     });
 
+    EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'study', 'flags', function(event, helper){
+        helper.setScriptOptions({
+            allowFutureDates: true
+        });
+
+        EHR.Server.TriggerManager.unregisterAllHandlersForQueryNameAndEvent('study', 'flags', EHR.Server.TriggerManager.Events.AFTER_INSERT);
+    });
+
     EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_INSERT, 'study', 'flags', function(helper, scriptErrors, row, oldRow){
         if (row.flag && row.Id && !row.enddate){
             var msg = triggerHelper.validateHousingConditionInsert(row.Id, row.flag, row.objectid || null);


### PR DESCRIPTION
#### Rationale
EHR flags AFTER_INSERT flag changed to a registered trigger, which changed the override behavior. This PR does the proper override for that trigger.

[Ticket 48396](https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=48396)

#### Changes
* Add override in onprc_triggers to allow future dates and not do default EHR AFTER_INSERT
