### PR TITLE
Use new AuditSummary schema for ETL deletes

### DIFF
--- a/GeneticsCore/resources/etls/MHC_Typing.xml
+++ b/GeneticsCore/resources/etls/MHC_Typing.xml
@@ -25,7 +25,7 @@
     </transforms>
 
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
-        <deletedRowsSource remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_delete_source" deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid" />
+        <deletedRowsSource remoteSource="PRIMESEQ_MHC" schemaName="geneticscore" queryName="mhc_delete_source" deletedSourceKeyColumnName="objectid" targetKeyColumnName="objectid" timestampColumnName="created"/>
     </incrementalFilter>
     <schedule>
         <cron expression="0 20 2 * * ?"/>

--- a/GeneticsCore/resources/queries/geneticscore/mhc_delete_source.sql
+++ b/GeneticsCore/resources/queries/geneticscore/mhc_delete_source.sql
@@ -1,10 +1,8 @@
 SELECT
-q.RowPk as objectid,
-q.created,
-q.createdby,
-q.created as modified,
-q.createdby as modifiedby,
-q.Container
+    q.RowPk as objectid,
+    q.created,
+    q.created as modified,
+    q.Container
 
-FROM auditLog.QueryUpdateAuditEvent q
-WHERE q.SchemaName = 'geneticscore' and q.QueryName = 'mhc_data' and q.comment = 'A row was deleted.'
+FROM AuditSummary.QueryUpdateAuditLog q
+WHERE q.SchemaName = 'geneticscore' and q.QueryName = 'mhc_data' and q.comment in ('A row was deleted.', 'Row was deleted.')


### PR DESCRIPTION
This will address the error in the MHC ETL: https://prime.ohsu.edu/query/ONPRC/Core%20Facilities/Genetics%20Core/MHC_Typing/executeQuery.view?schemaName=dataintegration&query.queryName=TransformRun&query.TransformRunId%7Eeq=279065.

I just need to deploy this to PRIMe-seq. We dont need any changes to prime, which is why I'm targeting 23.7.