### PR TITLE
Necropsy form request ids not doing initial load

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/NecropsyRequestInfoFormSection.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/NecropsyRequestInfoFormSection.java
@@ -16,7 +16,7 @@ public class NecropsyRequestInfoFormSection extends RequestFormSection
         if (maxItemsPerColumn != null)
         {
             // Make the form appear in two columns
-            JSONObject formConfig = new JSONObject(ret.get("formConfig"));
+            JSONObject formConfig = new JSONObject(ret.get("formConfig").toString());
             formConfig.put("maxItemsPerCol", maxItemsPerColumn);
             ret.put("formConfig", formConfig);
         }


### PR DESCRIPTION
#### Rationale
This is a subtle issue where the request id is not being automatically loaded into the store on form load. Once you edit a field in the request it is loaded, but if you accept the default values the request will be missing the request id. 

The JSON object constructor used is expecting a bean and this parameter is a multi-level JSON object. This PR stringifies the JSON object parameter so the JSON tokenizer will fully parse it.

#### Changes
* Update JSON object constructor parameter
