### PR TITLE
Backport changes to increase size of geneticscore column

### DIFF
--- a/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.13-17.14.sql
+++ b/GeneticsCore/resources/schemas/dbscripts/postgresql/geneticscore-17.13-17.14.sql
@@ -1,0 +1,1 @@
+ALTER TABLE geneticscore.mhc_data ALTER COLUMN marker TYPE varchar(1000);

--- a/GeneticsCore/resources/schemas/dbscripts/sqlserver/geneticscore-17.13-17.14.sql
+++ b/GeneticsCore/resources/schemas/dbscripts/sqlserver/geneticscore-17.13-17.14.sql
@@ -1,0 +1,1 @@
+ALTER TABLE geneticscore.mhc_data ALTER COLUMN marker nvarchar(1000);

--- a/GeneticsCore/src/org/labkey/GeneticsCore/GeneticsCoreModule.java
+++ b/GeneticsCore/src/org/labkey/GeneticsCore/GeneticsCoreModule.java
@@ -40,7 +40,7 @@ public class GeneticsCoreModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 17.13;
+        return 17.14;
     }
 
     @Override


### PR DESCRIPTION
This is backporting #837 and #836.  I didnt think we would need these on PRIMe, but forgot we ETL MHC data to PRIMe already.