### PR TITLE
JavaScriptDisplayColumn no longer renders inline event handlers

### DIFF
--- a/onprc_ehr/resources/queries/study/vetRecordReview.query.xml
+++ b/onprc_ehr/resources/queries/study/vetRecordReview.query.xml
@@ -21,7 +21,7 @@
                             <className>org.labkey.api.data.JavaScriptDisplayColumnFactory</className>
                             <properties>
                                 <property name="dependency">ehr/window/ManageRecordWindow.js</property>
-                                <property name="javaScriptEvents">onclick="EHR.window.ManageRecordWindow.buttonHandler(${Id:jsString}, ${objectid:jsString}, ${queryName:jsString}, '${dataRegionName}');"</property>
+                                <property name="onclick">EHR.window.ManageRecordWindow.buttonHandler(${Id:jsString}, ${objectid:jsString}, ${queryName:jsString}, '${dataRegionName}');</property>
                             </properties>
                         </displayColumnFactory>
                     </column>


### PR DESCRIPTION
#### Rationale
Adjust based on change to `JavaScriptDisplayColumn`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4970