### PR TITLE
Replace direct user of char() as string with SqlFragment in GroupConcats

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -889,12 +889,12 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
             if (realTable == null)
                 return;
 
-            SQLFragment sql = new SQLFragment("(select CAST(" + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("pl.category", "CASE WHEN pl.subcategory IS NULL THEN '' ELSE (" + ti.getSqlDialect().concatenate("': '", "pl.subcategory") + ") END")), true, true, getChr(ti) + "(10)").getSqlCharSequence() + "AS varchar(200)) as expr FROM " + realTable.getSelectName() + " pl WHERE pl.caseId = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND (pl.enddate IS NULL OR pl.enddate > {fn now()}))");
+            SQLFragment sql = new SQLFragment("(select CAST(" + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("pl.category", "CASE WHEN pl.subcategory IS NULL THEN '' ELSE (" + ti.getSqlDialect().concatenate("': '", "pl.subcategory") + ") END")), true, true, getNewlineSql(ti)).getSqlCharSequence() + "AS varchar(200)) as expr FROM " + realTable.getSelectName() + " pl WHERE pl.caseId = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND (pl.enddate IS NULL OR pl.enddate > {fn now()}))");
             ExprColumn newCol = new ExprColumn(ti, problemCategories, sql, JdbcType.VARCHAR, ti.getColumn("objectid"));
             newCol.setLabel("Active Master Problem(s)");
             ti.addColumn(newCol);
 
-            SQLFragment sql2 = new SQLFragment("(select CAST(" + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("pl.category", "CASE WHEN pl.subcategory IS NULL THEN '' ELSE (" + ti.getSqlDialect().concatenate("': '", "pl.subcategory") + ") END")), true, true, getChr(ti) + "(10)").getSqlCharSequence() + "AS varchar(200)) as expr FROM " + realTable.getSelectName() + " pl WHERE pl.caseId = " + ExprColumn.STR_TABLE_ALIAS + ".objectid)");
+            SQLFragment sql2 = new SQLFragment("(select CAST(" + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("pl.category", "CASE WHEN pl.subcategory IS NULL THEN '' ELSE (" + ti.getSqlDialect().concatenate("': '", "pl.subcategory") + ") END")), true, true, getNewlineSql(ti)).getSqlCharSequence() + "AS varchar(200)) as expr FROM " + realTable.getSelectName() + " pl WHERE pl.caseId = " + ExprColumn.STR_TABLE_ALIAS + ".objectid)");
             ExprColumn newCol2 = new ExprColumn(ti, "allProblemCategories", sql2, JdbcType.VARCHAR, ti.getColumn("objectid"));
             newCol2.setLabel("All Master Problem(s)");
             ti.addColumn(newCol2);
@@ -1065,12 +1065,11 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
         String name = "treatmentTimes";
         if (null == ti.getColumn(name) && null != ti.getColumn("objectid"))
         {
-            String chr = ti.getSqlDialect().isPostgreSQL() ? "chr" : "char";
             SQLFragment sql = new SQLFragment("COALESCE(" +
-                "(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("REPLICATE('0', 4 - LEN(tt.time))  + cast(tt.time as varchar(4))"), true, false, chr + "(10)").getSqlCharSequence() + " as _expr " +
+                "(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("REPLICATE('0', 4 - LEN(tt.time))  + cast(tt.time as varchar(4))"), true, false, getNewlineSql(ti)).getSqlCharSequence() + " as _expr " +
                 " FROM ehr.treatment_times tt " +
                 " WHERE tt.treatmentId = " + ExprColumn.STR_TABLE_ALIAS + ".objectid)" +
-                ", (SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("REPLICATE('0', 4 - LEN(ft.hourofday))  + cast(ft.hourofday as varchar(4))"), true, false, chr + "(10)").getSqlCharSequence() + " as _expr " +
+                ", (SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("REPLICATE('0', 4 - LEN(ft.hourofday))  + cast(ft.hourofday as varchar(4))"), true, false, getNewlineSql(ti)).getSqlCharSequence() + " as _expr " +
                 " FROM ehr_lookups.treatment_frequency f " +
                 " JOIN ehr_lookups.treatment_frequency_times ft ON (f.meaning = ft.frequency) WHERE f.rowid = " + ExprColumn.STR_TABLE_ALIAS + ".frequency)" +
                 ", 'Custom')"
@@ -1141,7 +1140,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
             ColumnInfo idCol = ti.getColumn("Id");
             assert idCol != null;
 
-            SQLFragment sql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("r.hx"), true, false, getChr(ti) + "(10)").getSqlCharSequence() + " FROM " + realTable.getSelectName() +
+            SQLFragment sql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("r.hx"), true, false, getNewlineSql(ti)).getSqlCharSequence() + " FROM " + realTable.getSelectName() +
                     " r WHERE r.participantId = " + ExprColumn.STR_TABLE_ALIAS + ".participantId AND r.hx IS NOT NULL AND (r.category != ? OR r.category IS NULL) AND r.date = (SELECT max(date) as expr FROM " + realTable.getSelectName() + " r2 "
                     + " WHERE r2.participantId = r.participantId AND r2.hx is not null AND (r2.category != ? OR r2.category IS NULL)))", ONPRC_EHRManager.REPLACED_SOAP, ONPRC_EHRManager.REPLACED_SOAP
             );
@@ -1331,7 +1330,6 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
         if (null == objectId || null == ti.getColumn("Id"))
             return;
 
-        String chr = ti.getSqlDialect().isPostgreSQL() ? "chr" : "char";
         SQLFragment latestHxSql = new SQLFragment("(SELECT " + prefix + " (" + "r.hx" + ") as _expr FROM " + realTable.getSelectName() +
                 " r WHERE "
                 + " r.caseid = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND "
@@ -1376,7 +1374,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
         ti.addColumn(recentCeg_plan);
 
         //does not use caseId
-        SQLFragment p2Sql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("'P2: '", "r.p2")), true, false, chr + "(10)").getSqlCharSequence() + " FROM " + realTable.getSelectName() +
+        SQLFragment p2Sql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("'P2: '", "r.p2")), true, false, getNewlineSql(ti)).getSqlCharSequence() + " FROM " + realTable.getSelectName() +
                 " r WHERE "
                 //+ " r.caseid = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND "
                 + " r.participantId = " + ExprColumn.STR_TABLE_ALIAS + ".participantId AND r.p2 IS NOT NULL AND CAST(r.date AS date) = CAST(? as date) AND (r.category != ? OR r.category IS NULL))", new Date(), ONPRC_EHRManager.REPLACED_SOAP);
@@ -1390,7 +1388,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
         yesterday.add(Calendar.DATE, -1);
 
         //does not use caseId
-        SQLFragment p2Sql2 = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("'P2: '", "r.p2")), true, false, chr + "(10)").getSqlCharSequence() + " FROM " + realTable.getSelectName() +
+        SQLFragment p2Sql2 = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment(ti.getSqlDialect().concatenate("'P2: '", "r.p2")), true, false, getNewlineSql(ti)).getSqlCharSequence() + " FROM " + realTable.getSelectName() +
                 " r WHERE "
                 //+ " r.caseid = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND "
                 + " r.participantId = " + ExprColumn.STR_TABLE_ALIAS + ".participantId AND r.p2 IS NOT NULL AND CAST(r.date AS date) = CAST(? as date) AND (r.category != ? OR r.category IS NULL))", yesterday.getTime(), ONPRC_EHRManager.REPLACED_SOAP);
@@ -1400,7 +1398,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
         ti.addColumn(yesterdaysP2);
 
         //uses caseId as a proxy for rounds
-        SQLFragment rmSql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("r.remark"), true, false, chr + "(10)").getSqlCharSequence() + " FROM " + realTable.getSelectName() +
+        SQLFragment rmSql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("r.remark"), true, false, getNewlineSql(ti)).getSqlCharSequence() + " FROM " + realTable.getSelectName() +
                 " r WHERE "
                 + " r.caseid = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND "
                 + " r.participantId = " + ExprColumn.STR_TABLE_ALIAS + ".participantId AND r.remark IS NOT NULL AND CAST(r.date AS date) = CAST(? as date) AND (r.category != ? OR r.category IS NULL))", new Date(), ONPRC_EHRManager.REPLACED_SOAP);
@@ -1411,7 +1409,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
         ti.addColumn(todaysRemarks);
 
         //TODO: convert to a real column
-        SQLFragment assesmentSql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("r.a"), true, false, chr + "(10)").getSqlCharSequence() + " FROM " + realTable.getSelectName() +
+        SQLFragment assesmentSql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("r.a"), true, false, getNewlineSql(ti)).getSqlCharSequence() + " FROM " + realTable.getSelectName() +
                 " r WHERE "
                 + " r.caseid = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND "
                 + " r.participantId = " + ExprColumn.STR_TABLE_ALIAS + ".participantId AND r.a IS NOT NULL AND r.date = " + ExprColumn.STR_TABLE_ALIAS + ".date AND (r.category != ? OR r.category IS NULL))", ONPRC_EHRManager.REPLACED_SOAP);
@@ -1448,8 +1446,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
         }
 
         //find any surgical procedures from the same date as this case
-        String chr = ti.getSqlDialect().isPostgreSQL() ? "chr" : "char";
-        SQLFragment procedureSql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("p.name"), false, false, chr + "(10)").getSqlCharSequence() +
+        SQLFragment procedureSql = new SQLFragment("(SELECT " + ti.getSqlDialect().getGroupConcat(new SQLFragment("p.name"), false, false, getNewlineSql(ti)).getSqlCharSequence() +
                 " FROM " + realTable.getSelectName() + " r " +
                 " JOIN ehr_lookups.procedures p ON (p.rowid = r.procedureid) " +
                 //r.caseid = " + ExprColumn.STR_TABLE_ALIAS + ".objectid AND


### PR DESCRIPTION
Probably in 23.7, LK introduced changes in how SQL is handled for group_concat(), which is used in a lot of EHR's calculated columns. The important change is that java code adding a group_concat column needs to supply the delimiter as a SQL Fragment, not a string. This patch (which is targeting 23.11, but you can do with as you like), addresses all the example I saw that needed to be changed.

If you run anything >=23.7 as-is, I expect that any of the columns being changed in this PR would show up as:

```
Value1charValue2charValue3
```

Rather than:
```
Value1
Value2
Value3
```

Note: this patch is dependent on a change in LDK module I made in 23.11, so backporting this to 23.7 by itself would not work.
