### PR TITLE
Clinical alerts modification

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalAlertsNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalAlertsNotification.java
@@ -99,7 +99,7 @@ public class ClinicalAlertsNotification extends ColonyAlertsNotification
         roomProblemSummary(c, u, msg, 30, 10);
 
         //Edited by Kollil: 12/18/23
-        //Removing this warning per request. Please check tkt # 10276 for details
+        //Removing this warning per request. Please check tkt # 10276 for details.
         //duplicateCases(c, u, msg);
 
         return msg.toString();

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalAlertsNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalAlertsNotification.java
@@ -97,7 +97,10 @@ public class ClinicalAlertsNotification extends ColonyAlertsNotification
         groupProblemSummary(c, u, msg, 30, 10);
         roomProblemSummary(c, u, msg, 7, 5);
         roomProblemSummary(c, u, msg, 30, 10);
-        duplicateCases(c, u, msg);
+
+        //Edited by Kollil: 12/18/23
+        //Removing this warning per request. Please check tkt # 10276 for details
+        //duplicateCases(c, u, msg);
 
         return msg.toString();
     }

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalRoundsNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalRoundsNotification.java
@@ -85,7 +85,7 @@ public class ClinicalRoundsNotification extends ColonyAlertsNotification
         StringBuilder msg = new StringBuilder();
 
         //Edited by Kollil: 12/18/23
-        //Removing this warning per request. Please check tkt # 10276 for details
+        //Removing this warning per request. Please check tkt # 10276 for details.
         //duplicateCases(c, u, msg);
         animalsWithoutRounds(c, u, msg);
         //animalsWithoutVetReview(c, u, msg);

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalRoundsNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/ClinicalRoundsNotification.java
@@ -84,7 +84,9 @@ public class ClinicalRoundsNotification extends ColonyAlertsNotification
     {
         StringBuilder msg = new StringBuilder();
 
-        duplicateCases(c, u, msg);
+        //Edited by Kollil: 12/18/23
+        //Removing this warning per request. Please check tkt # 10276 for details
+        //duplicateCases(c, u, msg);
         animalsWithoutRounds(c, u, msg);
         //animalsWithoutVetReview(c, u, msg);
 


### PR DESCRIPTION
Dupe cases warning is removed from two alerts.
