### PR TITLE
Modified pregnancy date confirmtion on the Snapshot reports to not al…

### DIFF
--- a/onprc_ehr/resources/queries/study/pregnancyGestation.sql
+++ b/onprc_ehr/resources/queries/study/pregnancyGestation.sql
@@ -26,5 +26,6 @@ INNER JOIN ehr_lookups.species p on (m.Id.DataSet.demographics.species = p.commo
 And m.date in (select max(s.date) AS d from study.pregnancyConfirmation s where s.id = m.id)
 And m.Id.DataSet.demographics.calculated_status.code = 'Alive'
 And p.Gestation is not null
-And m.outcome.birthDate is null
+And m.outcome.birthDate is null And (Select count(*) from ehr.snomed_tags stg where stg.code.code = 'F-30980' And stg.id = m.id
+                                      And stg.date >= m.date ) = 0
 And m.gestation_days is not null


### PR DESCRIPTION

Modified pregnancy date confirmtion on the Snapshot reports as not to allow displaying of pregnancy date when pregnancy was aborted.