### PR TITLE
Allow creators access to their own restricted issues

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
@@ -12,6 +12,7 @@ import org.labkey.api.query.ValidationError;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.util.Pair;
 
@@ -114,6 +115,11 @@ public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
 
     private boolean checkAccess(User user, @NotNull Issue issue, @Nullable Group groupWithAccess)
     {
+        // Creators have access to their own issues
+        User createdBy = UserManager.getUser(issue.getCreatedBy());
+        if (createdBy != null && createdBy.equals(user))
+            return true;
+
         // Assigned to users have access
         if (Objects.equals(issue.getAssignedTo(), user.getUserId()))
             return true;


### PR DESCRIPTION
#### Rationale
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49523)

This expands the rules regarding who can access issues in a restricted issue list to the following rules:
- administrators
- assigned to users
- users on the notify list
- members of the designated group (via config panel)
- creators will have access to their own issues but not others unless the above rules apply (this is the new addition)

#### Related Pull Requests
https://github.com/LabKey/platform/pull/5215

