### PR TITLE
Migrate inline javascript event handlers

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
@@ -32,11 +32,32 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
 
         this.callParent();
 
+        let anmId;
+
         if (this.subjectId){
+            anmId = this.subjectId;
             this.isLoading = true;
             this.setLoading(true);
             this.loadData();
         }
+
+        this.on('afterrender', function() {
+
+            var displayField = this.down('#flags');
+            if (displayField && displayField.getEl()) {
+
+                var anchor = displayField.getEl('onprcFlagsLink');
+
+                if (anchor) {
+                    Ext4.get(anchor).on('click', function(e) {
+                        e.preventDefault();
+                        if (anmId) {
+                            EHR.Utils.showFlagPopup(anmId, this);
+                        }
+                    });
+                }
+            }
+        }, this);
     },
 
     getBaseItems: function(){
@@ -128,7 +149,8 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
                     items: [{
                         xtype: 'displayfield',
                         fieldLabel: 'Flags',
-                        name: 'flags'
+                        name: 'flags',
+                        itemId: 'flags'
                     },{
                         xtype: 'displayfield',
                         fieldLabel: 'Last TB Date',
@@ -709,7 +731,7 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
             }
         }
 
-        toSet['flags'] = values.length ? '<a onclick="EHR.Utils.showFlagPopup(\'' + this.subjectId + '\', this);">' + values.join('<br>') + '</div>' : null;
+        toSet['flags'] = values.length ? '<a id="onprcFlagsLink">' + values.join('<br>') + '</div>' : null;
 
         if (behavevalues.length) {
             toSet['behaviorflag'] = behavevalues.length ? '<a onclick="EHR.Utils.showFlagPopup(\'' + this.subjectId + '\', this);">' + behavevalues.join('<br>') + '</div>' : null;

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ClinicalActionsDisplayColumn.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ClinicalActionsDisplayColumn.java
@@ -45,7 +45,7 @@ public class ClinicalActionsDisplayColumn extends DataColumn
         Object o = getValue(ctx);
         if (o != null)
         {
-            out.write("<a class=\"labkey-text-link cadc-row\" data-obj=\"" + PageFlowUtil.jsString(o.toString()) + "\">[Actions]");
+            out.write("<a class=\"labkey-text-link cadc-row\" data-obj=\"" + PageFlowUtil.filter(o.toString()) + "\">[Actions]");
             out.write("</a>");
             if (!_clickHandlerAdded)
             {

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ClinicalActionsDisplayColumn.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ClinicalActionsDisplayColumn.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.view.HttpView;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.template.ClientDependency;
 
@@ -36,6 +37,7 @@ public class ClinicalActionsDisplayColumn extends DataColumn
     {
         super(col);
     }
+    private boolean _clickHandlerAdded = false;
 
     @Override
     public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
@@ -43,8 +45,13 @@ public class ClinicalActionsDisplayColumn extends DataColumn
         Object o = getValue(ctx);
         if (o != null)
         {
-            out.write("<a onclick=\"EHR.panel.ClinicalManagementPanel.displayActionMenu(this, " + PageFlowUtil.jsString(o.toString()) + ")\">[Actions]");
+            out.write("<a class=\"labkey-text-link cadc-row\" data-obj=\"" + PageFlowUtil.jsString(o.toString()) + "\">[Actions]");
             out.write("</a>");
+            if (!_clickHandlerAdded)
+            {
+                HttpView.currentPageConfig().addHandlerForQuerySelector("a.cadc-row", "click", "EHR.panel.ClinicalManagementPanel.displayActionMenu(this, this.attributes.getNamedItem('data-obj').value);" );
+                _clickHandlerAdded = true;
+            }
         }
     }
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -1851,7 +1851,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdHCT"));
                             String id = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link hct-row\" data-runid=" + PageFlowUtil.jsString(runId) + " data-id=" + PageFlowUtil.jsString(id) + ">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link hct-row\" data-runid=\"" + PageFlowUtil.filter(runId) + "\" data-id=\"" + PageFlowUtil.filter(id) + "\">" + getFormattedHtml(ctx) + "</a></span>");
                             if (!_hctRowClickHandlerAdded)
                             {
                                 HttpView.currentPageConfig().addHandlerForQuerySelector("a.hct-row", "click", "EHR.panel.LabworkSummaryPanel.showRunSummary(this.attributes.getNamedItem('data-runid').value, this.attributes.getNamedItem('data-id').value, this);");
@@ -1977,7 +1977,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         String objectid = (String)ctx.get("objectid");
                         String id = (String)ctx.get("Id");
 
-                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link cs-h-row\" data-objectid=" + PageFlowUtil.jsString(objectid) + " data-id=" + PageFlowUtil.jsString(id) + ">[Show Case Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link cs-h-row\" data-objectid=\"" + PageFlowUtil.filter(objectid) + "\" data-id=\"" + PageFlowUtil.filter(id) + "\">[Show Case Hx]</a></span>");
                         if (!_caseHistoryClickHandlerAdded)
                         {
                             HttpView.currentPageConfig().addHandlerForQuerySelector("a.cs-h-row", "click", "EHR.window.CaseHistoryWindow.showCaseHistory(this.attributes.getNamedItem('data-objectid').value, this.attributes.getNamedItem('data-id').value, this);");

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -60,6 +60,7 @@ import org.labkey.api.study.DatasetTable;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.HttpView;
 import org.labkey.onprc_ehr.ONPRC_EHRManager;
 import org.labkey.onprc_ehr.ONPRC_EHRModule;
 
@@ -79,6 +80,9 @@ import java.util.Set;
 public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
 {
     private static final Logger _log = LogManager.getLogger(ONPRC_EHRCustomizer.class);
+
+    private boolean _surgeryChecklistClickHandlerAdded = false;
+    private boolean _caseHistoryClickHandlerAdded = false;
 
     public ONPRC_EHRCustomizer()
     {
@@ -1810,7 +1814,12 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdPLT"));
                             String id = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link srg-chk-lst\" data-runid=" + PageFlowUtil.jsString(runId) + " data-id=" + PageFlowUtil.jsString(id) + ">" + getFormattedHtml(ctx) + "</a></span>");
+                            if (!_surgeryChecklistClickHandlerAdded)
+                            {
+                                HttpView.currentPageConfig().addHandlerForQuerySelector("a.srg-chk-lst", "click", "EHR.panel.LabworkSummaryPanel.showRunSummary(this.attributes.getNamedItem('data-runid').value, this.attributes.getNamedItem('data-id').value, this);");
+                                _surgeryChecklistClickHandlerAdded = true;
+                            }
                         }
 
                         @Override
@@ -1841,7 +1850,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdHCT"));
                             String id = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedHtml(ctx) + "</a></span>");
                         }
 
                         @Override
@@ -1962,7 +1971,11 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         String objectid = (String)ctx.get("objectid");
                         String id = (String)ctx.get("Id");
 
-                        out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.window.CaseHistoryWindow.showCaseHistory('" + objectid + "', '" + id + "', this);\">[Show Case Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a onclick=\"EHR.window.CaseHistoryWindow.showCaseHistory('" + objectid + "', '" + id + "', this);\">[Show Case Hx]</a></span>");
+                        if (!_caseHistoryClickHandlerAdded)
+                        {
+
+                        }
                     }
 
                     @Override

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -83,6 +83,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
 
     private boolean _surgeryChecklistClickHandlerAdded = false;
     private boolean _caseHistoryClickHandlerAdded = false;
+    private boolean _hctRowClickHandlerAdded = false;
 
     public ONPRC_EHRCustomizer()
     {
@@ -1814,7 +1815,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdPLT"));
                             String id = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link srg-chk-lst\" data-runid=" + PageFlowUtil.jsString(runId) + " data-id=" + PageFlowUtil.jsString(id) + ">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link srg-chk-lst\" data-runid=\"" + PageFlowUtil.jsString(runId) + "\" data-id=\"" + PageFlowUtil.jsString(id) + "\">" + getFormattedHtml(ctx) + "</a></span>");
                             if (!_surgeryChecklistClickHandlerAdded)
                             {
                                 HttpView.currentPageConfig().addHandlerForQuerySelector("a.srg-chk-lst", "click", "EHR.panel.LabworkSummaryPanel.showRunSummary(this.attributes.getNamedItem('data-runid').value, this.attributes.getNamedItem('data-id').value, this);");
@@ -1850,7 +1851,12 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdHCT"));
                             String id = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a onclick=\"EHR.panel.LabworkSummaryPanel.showRunSummary(" + PageFlowUtil.jsString(runId) + ", '" + id + "', this);\">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link hct-row\" data-runid=\"" + PageFlowUtil.jsString(runId) + "\" data-id=\"" + PageFlowUtil.jsString(id) + "\">" + getFormattedHtml(ctx) + "</a></span>");
+                            if (!_hctRowClickHandlerAdded)
+                            {
+                                HttpView.currentPageConfig().addHandlerForQuerySelector("a.hct-row", "click", "EHR.panel.LabworkSummaryPanel.showRunSummary(this.attributes.getNamedItem('data-runid').value, this.attributes.getNamedItem('data-id').value, this);");
+                                _hctRowClickHandlerAdded = true;
+                            }
                         }
 
                         @Override
@@ -1971,10 +1977,11 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         String objectid = (String)ctx.get("objectid");
                         String id = (String)ctx.get("Id");
 
-                        out.write("<span style=\"white-space:nowrap\"><a onclick=\"EHR.window.CaseHistoryWindow.showCaseHistory('" + objectid + "', '" + id + "', this);\">[Show Case Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link cs-h-row\" data-objectid=\"" + PageFlowUtil.jsString(objectid) + "\" data-id=\"" + PageFlowUtil.jsString(id) + "\">[Show Case Hx]</a></span>");
                         if (!_caseHistoryClickHandlerAdded)
                         {
-
+                            HttpView.currentPageConfig().addHandlerForQuerySelector("a.cs-h-row", "click", "EHR.window.CaseHistoryWindow.showCaseHistory(this.attributes.getNamedItem('data-objectid').value, this.attributes.getNamedItem('data-id').value, this);");
+                            _caseHistoryClickHandlerAdded = true;
                         }
                     }
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -1815,7 +1815,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdPLT"));
                             String id = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link srg-chk-lst\" data-runid=" + PageFlowUtil.jsString(runId) + " data-id=" + PageFlowUtil.jsString(id) + ">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link srg-chk-lst\" data-runid=\"" + PageFlowUtil.filter(runId) + "\" data-id=\"" + PageFlowUtil.filter(id) + "\">" + getFormattedHtml(ctx) + "</a></span>");
                             if (!_surgeryChecklistClickHandlerAdded)
                             {
                                 HttpView.currentPageConfig().addHandlerForQuerySelector("a.srg-chk-lst", "click", "EHR.panel.LabworkSummaryPanel.showRunSummary(this.attributes.getNamedItem('data-runid').value, this.attributes.getNamedItem('data-id').value, this);");

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/ONPRC_EHRCustomizer.java
@@ -1815,7 +1815,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdPLT"));
                             String id = (String)ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link srg-chk-lst\" data-runid=\"" + PageFlowUtil.jsString(runId) + "\" data-id=\"" + PageFlowUtil.jsString(id) + "\">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link srg-chk-lst\" data-runid=" + PageFlowUtil.jsString(runId) + " data-id=" + PageFlowUtil.jsString(id) + ">" + getFormattedHtml(ctx) + "</a></span>");
                             if (!_surgeryChecklistClickHandlerAdded)
                             {
                                 HttpView.currentPageConfig().addHandlerForQuerySelector("a.srg-chk-lst", "click", "EHR.panel.LabworkSummaryPanel.showRunSummary(this.attributes.getNamedItem('data-runid').value, this.attributes.getNamedItem('data-id').value, this);");
@@ -1851,7 +1851,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         {
                             String runId = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "runIdHCT"));
                             String id = (String) ctx.get(new FieldKey(getBoundColumn().getFieldKey().getParent(), "Id"));
-                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link hct-row\" data-runid=\"" + PageFlowUtil.jsString(runId) + "\" data-id=\"" + PageFlowUtil.jsString(id) + "\">" + getFormattedHtml(ctx) + "</a></span>");
+                            out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link hct-row\" data-runid=" + PageFlowUtil.jsString(runId) + " data-id=" + PageFlowUtil.jsString(id) + ">" + getFormattedHtml(ctx) + "</a></span>");
                             if (!_hctRowClickHandlerAdded)
                             {
                                 HttpView.currentPageConfig().addHandlerForQuerySelector("a.hct-row", "click", "EHR.panel.LabworkSummaryPanel.showRunSummary(this.attributes.getNamedItem('data-runid').value, this.attributes.getNamedItem('data-id').value, this);");
@@ -1977,7 +1977,7 @@ public class ONPRC_EHRCustomizer extends AbstractTableCustomizer
                         String objectid = (String)ctx.get("objectid");
                         String id = (String)ctx.get("Id");
 
-                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link cs-h-row\" data-objectid=\"" + PageFlowUtil.jsString(objectid) + "\" data-id=\"" + PageFlowUtil.jsString(id) + "\">[Show Case Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link cs-h-row\" data-objectid=" + PageFlowUtil.jsString(objectid) + " data-id=" + PageFlowUtil.jsString(id) + ">[Show Case Hx]</a></span>");
                         if (!_caseHistoryClickHandlerAdded)
                         {
                             HttpView.currentPageConfig().addHandlerForQuerySelector("a.cs-h-row", "click", "EHR.window.CaseHistoryWindow.showCaseHistory(this.attributes.getNamedItem('data-objectid').value, this.attributes.getNamedItem('data-id').value, this);");

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/VetReviewDisplayColumn.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/VetReviewDisplayColumn.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
 
 import java.io.IOException;
@@ -39,6 +40,7 @@ public class VetReviewDisplayColumn extends DataColumn
     {
         super(col);
     }
+    private boolean _clickHandlerRegistered = false;
 
     @Override
     public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
@@ -64,7 +66,13 @@ public class VetReviewDisplayColumn extends DataColumn
                     text = text.replaceAll("\\*\\*", "<span style=\"background-color: yellow;\">\\*\\*</span>");
                 }
 
-                out.write("<a style=\"max-width: 500px;\" onclick=\"EHR.panel.ClinicalManagementPanel.replaceSoap({objectid: " + PageFlowUtil.jsString(StringUtils.trimToNull(tokens[2])) + ", scope: this, callback: function(){EHR.panel.ClinicalManagementPanel.updateVetColumn(this, arguments[0], arguments[1]);}});\">");
+                out.write("<a style=\"max-width: 500px;\" class=\"labkey-text-link vrdc-row\" data-objectid=\"" + PageFlowUtil.filter(StringUtils.trimToNull(tokens[2])) + "\">");
+
+                if (!_clickHandlerRegistered)
+                {
+                    HttpView.currentPageConfig().addHandlerForQuerySelector("a.vrdc-row", "click", "EHR.panel.ClinicalManagementPanel.replaceSoap({objectid: this.attributes.getNamedItem('data-objectid').value, scope: this, callback: function(){EHR.panel.ClinicalManagementPanel.updateVetColumn(this, arguments[0], arguments[1]);}});" );
+                    _clickHandlerRegistered = true;
+                }
                 out.write(text);
                 out.write("</a>");
             }


### PR DESCRIPTION
#### Rationale
A strict (no 'unsafe-inline' directive) CSP forbids all inline events. Instead, events must be attached via JavaScript inside a properly nonced script tag

#### Changes
* SnapshotPanel.js
* ONPRC_EHRCustomizer.java
* ClinicalActionsDisplayColumn.java
* VetReviewDisplayColumn.java