### PR TITLE
Add scriptNonce in html files

### DIFF
--- a/onprc_ehr/resources/views/EnvironmentalDetails.html
+++ b/onprc_ehr/resources/views/EnvironmentalDetails.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
     Ext4.onReady(function (){
 

--- a/onprc_ehr/resources/views/EnvironmentalLandingpage.html
+++ b/onprc_ehr/resources/views/EnvironmentalLandingpage.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
     Ext4.onReady(function(){
         var webpart = <%=webpartContext%>;

--- a/onprc_ehr/resources/views/EnvironmentalenterData.html
+++ b/onprc_ehr/resources/views/EnvironmentalenterData.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="<%=scriptNonce%>">
 
 Ext4.onReady(function (){
     var webpart = <%=webpartContext%>;


### PR DESCRIPTION
Rationale
Every HTML script tag requires a nonce with a value that matching the request-specific value in the response CSP header
