### PR TITLE
Switch cagemates demographic provider to async

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/demographics/CagematesDemographicsProvider.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/demographics/CagematesDemographicsProvider.java
@@ -43,6 +43,12 @@ public class CagematesDemographicsProvider extends AbstractListDemographicsProvi
     }
 
     @Override
+    public boolean isAsync()
+    {
+        return true;
+    }
+
+    @Override
     protected Set<FieldKey> getFieldKeys()
     {
         Set<FieldKey> keys = new HashSet<>();
@@ -57,22 +63,10 @@ public class CagematesDemographicsProvider extends AbstractListDemographicsProvi
     @Override
     public Set<String> getIdsToUpdate(Container c, String id, Map<String, Object> originalProps, Map<String, Object> newProps)
     {
-        List<Map<String, Object>> oldList = originalProps == null ? null : (List)originalProps.get(_propName);
         List<Map<String, Object>> newList = newProps == null ? null : (List)newProps.get(_propName);
         Set<String> ret = new TreeSet<>();
 
-        List<String> oldAnimals = oldList == null || oldList.isEmpty() ? Collections.emptyList() : toList(oldList.get(0).get("animals"));
         List<String> newAnimals = newList == null || newList.isEmpty() ? Collections.emptyList() : toList(newList.get(0).get("animals"));
-        if (oldAnimals.equals(newAnimals))
-        {
-            if (!oldAnimals.isEmpty())
-            {
-                _log.info(id + ": cagemates before/after move are identical, no changes needed.  list size: " + oldAnimals.size());
-            }
-            return Collections.emptySet();
-        }
-
-        ret.addAll(oldAnimals);
         ret.addAll(newAnimals);
         ret.remove(id);
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/demographics/CagematesDemographicsProvider.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/demographics/CagematesDemographicsProvider.java
@@ -63,11 +63,15 @@ public class CagematesDemographicsProvider extends AbstractListDemographicsProvi
     @Override
     public Set<String> getIdsToUpdate(Container c, String id, Map<String, Object> originalProps, Map<String, Object> newProps)
     {
+        List<Map<String, Object>> oldList = originalProps == null ? null : (List)originalProps.get(_propName);
         List<Map<String, Object>> newList = newProps == null ? null : (List)newProps.get(_propName);
         Set<String> ret = new TreeSet<>();
 
+        List<String> oldAnimals = oldList == null || oldList.isEmpty() ? Collections.emptyList() : toList(oldList.get(0).get("animals"));
         List<String> newAnimals = newList == null || newList.isEmpty() ? Collections.emptyList() : toList(newList.get(0).get("animals"));
+
         ret.addAll(newAnimals);
+        ret.addAll(oldAnimals);
         ret.remove(id);
 
         if (!ret.isEmpty())


### PR DESCRIPTION
#### Rationale
demographicsPaired, used in the cagemates demographic provider is running long enough to cause some birth updates to timeout on trigger time limit. Use the async option in the related PR to make the cagemates demographic provider run in another thread and not in sync with the triggers.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/775

#### Changes
* Set isAsync to true
* Update to get all related Ids
