### PR TITLE
Move another flag popup to avoid inline script

### DIFF
--- a/onprc_ehr/resources/queries/study/treatmentSchedule.query.xml
+++ b/onprc_ehr/resources/queries/study/treatmentSchedule.query.xml
@@ -190,16 +190,12 @@
                             <onClick>
                                 EHR.DatasetButtons.historyHandler(dataRegion, dataRegionName);
                             </onClick>
-                            <!--<target>javascript:void(0)</target>-->
                         </item>
                         <item text="Return Distinct Values">
                             <onClick>
                                 EHR.window.GetDistinctWindow.getDistinctHandler(dataRegionName);
                             </onClick>
                         </item>
-                    </item>
-                    <item text=" " requiresSelection="true" insertAfter="More Actions">
-                        <onClick>javascript:void(0);</onClick>
                     </item>
                 </buttonBarOptions>
             </table>

--- a/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
@@ -46,15 +46,18 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
             var displayField = this.down('#flags');
             if (displayField && displayField.getEl()) {
 
-                var anchor = displayField.getEl('onprcFlagsLink');
+                var anchors = [displayField.getEl('onprcFlagsLink'), displayField.getEl('onprcBehaviorFlagsLink')];
 
-                if (anchor) {
-                    Ext4.get(anchor).on('click', function(e) {
-                        e.preventDefault();
-                        if (anmId) {
-                            EHR.Utils.showFlagPopup(anmId, this);
-                        }
-                    });
+                for (let i = 0; i < anchors.length; i++) {
+                    let anchor = anchors[i];
+                    if (anchor) {
+                        Ext4.get(anchor).on('click', function(e) {
+                            e.preventDefault();
+                            if (anmId) {
+                                EHR.Utils.showFlagPopup(anmId, this);
+                            }
+                        });
+                    }
                 }
             }
         }, this);
@@ -733,8 +736,10 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
 
         toSet['flags'] = values.length ? '<a id="onprcFlagsLink">' + values.join('<br>') + '</div>' : null;
 
+        behavevalues = ['test'];
+
         if (behavevalues.length) {
-            toSet['behaviorflag'] = behavevalues.length ? '<a onclick="EHR.Utils.showFlagPopup(\'' + this.subjectId + '\', this);">' + behavevalues.join('<br>') + '</div>' : null;
+            toSet['behaviorflag'] = '<a id="onprcBehaviorFlagsLink">' + behavevalues.join('<br>') + '</div>';
         }
         else
         {


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/onprcEHRModules/pull/966 migrated one in-line click handler for a flags popup, but missed a second.

#### Changes
* Attach the behavior flag popup in the same way as a the regular flag