### PR TITLE
23.11 fb finance update for reversals

### DIFF
--- a/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
+++ b/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
@@ -427,10 +427,10 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
             }
             //added as part of Finance 11380 update by Gary
             //this issues is causing error
-           /* if (this.down('#doChangedebitAlias').getValue() && !this.down('#newDebitAlias').getValue()){
+           if (this.down('#doChangedebitAlias').getValue() && !this.down('#newDebitAliasField').getValue()){
                 Ext4.Msg.alert('Error', 'You have checked that you want to alter the debit alias, but did not supply the new alias.  Either enter an alias or uncheck the field');
                 return;
-            }*/
+            }
 
             if (this.down('#doChangeCreditAlias').getValue() && !this.down('#creditAliasField').getValue()){
                 Ext4.Msg.alert('Error', 'You have checked that you want to alter the credit alias, but did not supply the new alias.  Either enter an alias or uncheck the field');
@@ -489,13 +489,13 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
                     toApply.debitedaccount = Ext4.String.trim(toApply.debitedaccount);
                 }
             }
-           /*//Added by Gary as part of 11380 update
-            if (this.down('#doChangeDebitlias').getValue()){
-                toApply.debitedaccount = this.down('##newDebitAlias'').getValue();
-                if (toApply.creditedaccount){
-                    toApply.creditedaccount = Ext4.String.trim(toApply.creditedaccount);
+           //Added by Gary as part of 11380 update
+            if (this.down('#doChangedebitAlias').getValue()){
+                toApply.debitedaccount = this.down('#newDebitAliasField').getValue();
+                if (toApply.debitedaccount){
+                    toApply.debitedaccount = Ext4.String.trim(toApply.debitedaccount);
                 }
-            }*/
+            }
             if (this.down('#doChangeCreditAlias').getValue()){
                 toApply.creditedaccount = this.down('#creditAliasField').getValue();
                 if (toApply.creditedaccount){

--- a/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
+++ b/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
@@ -299,7 +299,35 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
                     }
                 }]
             });
-
+            // added per request in Finance Tracker Issue 11380
+            //debit alias
+            items.push({
+                xtype: 'checkbox',
+                boxLabel: 'Change Debit Alias',
+                itemId: 'doChangedebitAlias',
+                listeners: {
+                    change: function(field, val){
+                        field.up('panel').down('#debitPanel').setVisible(val);
+                    }
+                }
+            },{
+                xtype: 'panel',
+                itemId: 'debitPanel',
+                hidden: true,
+                defaults: {
+                    border: false,
+                    style: 'margin-left: 20px;'
+                },
+                items: [{
+                    xtype: 'textfield',
+                    itemId: 'debitAliasField',
+                    width: 400,
+                    labelWidth: 150,
+                    fieldLabel: 'Debit Alias',
+                    displayField: 'debitAlias',
+                    valueField: 'debitAlias'
+                }]
+            });
             //credit alias
             items.push({
                 xtype: 'checkbox',
@@ -396,7 +424,10 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
                 return;
 
             }
-
+            if (this.down('#doChangeDebitAlias').getValue() && !this.down('#debitAliasField').getValue()){
+                Ext4.Msg.alert('Error', 'You have checked that you want to alter the debit alias, but did not supply the new alias.  Either enter an alias or uncheck the field');
+                return;
+            }
             if (this.down('#doChangeCreditAlias').getValue() && !this.down('#creditAliasField').getValue()){
                 Ext4.Msg.alert('Error', 'You have checked that you want to alter the credit alias, but did not supply the new alias.  Either enter an alias or uncheck the field');
                 return;

--- a/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
+++ b/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
@@ -2,6 +2,8 @@
  * Copyright (c) 2013 LabKey Corporation
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ * Modified jonesga October 30, 2024
+ * **Per Finance Issue Tracker 11380 added debit Aklias add function to allow change of debit alias when no center project is associated
  */
 Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
     extend: 'Ext.window.Window',

--- a/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
+++ b/onprc_billing/resources/web/onprc_billing/window/ReverseChargeWindow.js
@@ -299,8 +299,8 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
                     }
                 }]
             });
-            // added per request in Finance Tracker Issue 11380
             //debit alias
+            //Added b y Gary 2024-10-25 Finance issue 11380
             items.push({
                 xtype: 'checkbox',
                 boxLabel: 'Change Debit Alias',
@@ -320,14 +320,15 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
                 },
                 items: [{
                     xtype: 'textfield',
-                    itemId: 'debitAliasField',
+                    itemId: 'newDebitAliasField',
                     width: 400,
                     labelWidth: 150,
                     fieldLabel: 'Debit Alias',
-                    displayField: 'debitAlias',
-                    valueField: 'debitAlias'
+                    displayField: 'newDebitalias',
+                    valueField: 'NewDebitalias'
                 }]
             });
+
             //credit alias
             items.push({
                 xtype: 'checkbox',
@@ -424,10 +425,13 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
                 return;
 
             }
-            if (this.down('#doChangeDebitAlias').getValue() && !this.down('#debitAliasField').getValue()){
+            //added as part of Finance 11380 update by Gary
+            //this issues is causing error
+           /* if (this.down('#doChangedebitAlias').getValue() && !this.down('#newDebitAlias').getValue()){
                 Ext4.Msg.alert('Error', 'You have checked that you want to alter the debit alias, but did not supply the new alias.  Either enter an alias or uncheck the field');
                 return;
-            }
+            }*/
+
             if (this.down('#doChangeCreditAlias').getValue() && !this.down('#creditAliasField').getValue()){
                 Ext4.Msg.alert('Error', 'You have checked that you want to alter the credit alias, but did not supply the new alias.  Either enter an alias or uncheck the field');
                 return;
@@ -475,6 +479,9 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
             var creditAliasField = this.down('#creditAliasField');
             var unitCostField = this.down('#unitCostField');
 
+
+
+
             if (this.down('#doChangeProject').getValue()){
                 toApply.project = this.down('#projectField').getValue();
                 toApply.debitedaccount = this.down('#debitAliasField').getValue();
@@ -482,7 +489,13 @@ Ext4.define('ONPRC_Billing.window.ReverseChargeWindow', {
                     toApply.debitedaccount = Ext4.String.trim(toApply.debitedaccount);
                 }
             }
-
+           /*//Added by Gary as part of 11380 update
+            if (this.down('#doChangeDebitlias').getValue()){
+                toApply.debitedaccount = this.down('##newDebitAlias'').getValue();
+                if (toApply.creditedaccount){
+                    toApply.creditedaccount = Ext4.String.trim(toApply.creditedaccount);
+                }
+            }*/
             if (this.down('#doChangeCreditAlias').getValue()){
                 toApply.creditedaccount = this.down('#creditAliasField').getValue();
                 if (toApply.creditedaccount){


### PR DESCRIPTION
#### Rationale
A request from Finance to allow an editor to change the debit alias when a account does not have a center project.  This primarily is for Core Accounts.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Changes to reverseChargewindow.js
