### PR TITLE
Mark modules that support both databases

### DIFF
--- a/GeneticsCore/module.properties
+++ b/GeneticsCore/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.GeneticsCore.GeneticsCoreModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/HormoneAssay/module.properties
+++ b/HormoneAssay/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.hormoneassay.HormoneAssayModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/mergesync/module.properties
+++ b/mergesync/module.properties
@@ -1,2 +1,2 @@
 ModuleClass: org.labkey.mergesync.MergeSyncModule
-ManageVersion: false
+ManageVersion: falseSupportedDatabases: mssql, pgsql

--- a/mergesync/module.properties
+++ b/mergesync/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.mergesync.MergeSyncModule
-ManageVersion: falseSupportedDatabases: mssql, pgsql
+ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/onprc_reports/module.properties
+++ b/onprc_reports/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.onprc_reports.ONPRC_ReportsModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/treatmentETL/module.properties
+++ b/treatmentETL/module.properties
@@ -2,3 +2,4 @@ Name: TreatmentETL
 ModuleClass: org.labkey.api.module.SimpleModule
 RequiredServerVersion: 15.2
 ManageVersion: false
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only