### PR TITLE
Bigiron dev dependency

### DIFF
--- a/onprc_ehr/build.gradle
+++ b/onprc_ehr/build.gradle
@@ -15,6 +15,7 @@ dependencies
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: 'published', depExtension: 'module')
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premiumModules:dataintegration", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premiumModules:bigiron", depProjectConfig: 'published', depExtension: 'module')
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premiumModules:premium", depProjectConfig: 'published', depExtension: 'module')
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premiumModules:ldap", depProjectConfig: 'published', depExtension: 'module')


### PR DESCRIPTION
#### Rationale
Pull in bigiron module jar for external devs not building premiumModules source.

#### Changes
* bigiron dependency
