### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/GeneticsCore/resources/views/mhcDataDashboard.view.xml
+++ b/GeneticsCore/resources/views/mhcDataDashboard.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MHC Typing Dashboard">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
 
     </dependencies>

--- a/ONPRC_EHR_ComplianceDB/resources/views/enterData.view.xml
+++ b/ONPRC_EHR_ComplianceDB/resources/views/enterData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="portal">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="ehr_compliancedb/panel/EnterDataPanel.js"/>

--- a/onprc_ehr/resources/views/EnvironmentalDetails.view.xml
+++ b/onprc_ehr/resources/views/EnvironmentalDetails.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="portal">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="onprc_ehr/panel/EnvironmentalDetailsPanel.js"/>

--- a/onprc_ehr/resources/views/EnvironmentalenterData.view.xml
+++ b/onprc_ehr/resources/views/EnvironmentalenterData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="portal">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="onprc_ehr/panel/EnvironmentalEnterDataPanel.js"/>

--- a/onprc_ehr/resources/views/ehrAdmin.view.xml
+++ b/onprc_ehr/resources/views/ehrAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Administration">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/onprc_ehr/resources/views/ehrAdmin.view.xml
+++ b/onprc_ehr/resources/views/ehrAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Administration">
     <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/onprc_ehr/resources/views/enterData.view.xml
+++ b/onprc_ehr/resources/views/enterData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="portal">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="onprc_ehr/panel/EnterDataPanel.js"/>

--- a/sla/resources/views/createPurchaseOrder.view.xml
+++ b/sla/resources/views/createPurchaseOrder.view.xml
@@ -5,9 +5,9 @@
     The permissions setting ensures that any users with 'insert' permission can see thie view/action.
 -->
 <view xmlns="http://labkey.org/data/xml/view" title="Create Purchase Order" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4" />
         <dependency path="sla/purchaseOrder" />

--- a/sla/resources/views/etlAdmin.view.xml
+++ b/sla/resources/views/etlAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="SLA ETL Administration">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="sla.context" />
     </dependencies>

--- a/sla/resources/views/purchaseOrderReport.view.xml
+++ b/sla/resources/views/purchaseOrderReport.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Purchase Order Report" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4" />
     </dependencies>

--- a/sla/resources/views/reviewPurchaseOrder.view.xml
+++ b/sla/resources/views/reviewPurchaseOrder.view.xml
@@ -5,9 +5,9 @@
     The permissions setting ensures that any users with 'read' permission can see thie view/action.
 -->
 <view xmlns="http://labkey.org/data/xml/view" title="Review Purchase Order" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4" />
         <dependency path="sla/purchaseOrder" />

--- a/sla/resources/views/updatePurchaseOrder.view.xml
+++ b/sla/resources/views/updatePurchaseOrder.view.xml
@@ -5,9 +5,9 @@
     The permissions setting ensures that any users with 'update' permission can see thie view/action.
 -->
 <view xmlns="http://labkey.org/data/xml/view" title="Update Purchase Order" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4" />
         <dependency path="sla/purchaseOrder" />

--- a/sla/resources/views/viewPurchaseOrderDrafts.view.xml
+++ b/sla/resources/views/viewPurchaseOrderDrafts.view.xml
@@ -5,9 +5,9 @@
     The permissions setting ensures that any users with 'insert' permission can see this view/action.
 -->
 <view xmlns="http://labkey.org/data/xml/view" title="Purchase Order Saved Drafts" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4" />
     </dependencies>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.