### PR TITLE
Ticket 52206: Remove hard-coded test value from Behavior Alert 

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/SnapshotPanel.js
@@ -735,8 +735,6 @@ Ext4.define('onprc_ehr.panel.SnapshotPanel', {
 
         toSet['flags'] = values.length ? '<a id="onprcFlagsLink">' + values.join('<br>') + '</div>' : null;
 
-        behavevalues = ['test'];
-
         if (behavevalues.length) {
             toSet['behaviorflag'] = '<a id="onprcBehaviorFlagsLink">' + behavevalues.join('<br>') + '</div>';
         }


### PR DESCRIPTION
#### Rationale
In work to remove in-line script, I accidentally left some testing code behind

#### Changes
* Delete the dummy value used for testing