### PR TITLE
Relax related issue rules for restricted issues

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/issues/RestrictedIssueProviderImpl.java
@@ -96,21 +96,6 @@ public class RestrictedIssueProviderImpl implements RestrictedIssueProvider
                 return false;
             }
         }
-
-        // the user must also have access to all related issues
-        for (Issue related : relatedIssues)
-        {
-            Container relatedContainer = ContainerManager.getForId(related.getContainerId());
-            if (relatedContainer != null && isRestrictedIssueTracker(relatedContainer, related.getIssueDefName()))
-            {
-                Group relatedGroup = getRestrictedIssueListGroup(relatedContainer, related.getIssueDefName());
-                if (!checkAccess(user, related, relatedGroup))
-                {
-                    errors.add(new SimpleValidationError(String.format("A related issue : %d is in a restricted issue list. You do not have access to that issue", related.getIssueId())));
-                    return false;
-                }
-            }
-        }
         return true;
     }
 

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -153,7 +153,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
     private void verifyIssueAccess(String issueID, boolean shouldHaveAccess)
     {
         pushLocation();
-        clickAndWait(Locator.linkContainingText(issueID));
+        waitAndClickAndWait(Locator.linkContainingText(issueID));
         if (shouldHaveAccess)
             assertTextNotPresent(ACCESS_ERROR_MSG);
         else
@@ -246,7 +246,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         {
             assertElementPresent(relatedIssueLink);
             // related link should also navigate properly
-            clickAndWait(relatedIssueLink);
+            waitAndClickAndWait(relatedIssueLink);
             assertTextNotPresent(ACCESS_ERROR_MSG);
         }
         else

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -241,10 +241,10 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
     private void verifyRelatedIssueAccess(String issueID, String relatedIssueID, boolean shouldHaveRelatedAccess)
     {
-        Locator issueLink = Locator.linkContainingText(issueID);
+        Locator issueLink = getIssueLinkLocator(issueID);
         waitForElement(issueLink, defaultWaitForPage);
         pushLocation();
-        clickAndWait(Locator.linkContainingText(issueID));
+        clickAndWait(issueLink);
         Locator relatedIssueLink = getIssueLinkLocator(relatedIssueID);
         if (shouldHaveRelatedAccess)
         {

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -6,7 +6,6 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.EHR;
 import org.labkey.test.categories.ONPRC;
 import org.labkey.test.pages.issues.DetailsPage;
@@ -20,7 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-@Category({CustomModules.class, EHR.class, ONPRC.class})
+@Category({EHR.class, ONPRC.class})
 public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements SqlserverOnlyTest
 {
     private final IssuesHelper _issuesHelper;

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -155,7 +155,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         Locator issueLink = Locator.linkContainingText(issueID);
         waitForElement(issueLink, defaultWaitForPage);
         pushLocation();
-        clickAndWait(issueLink);
+        waitAndClickAndWait(issueLink);
         if (shouldHaveAccess)
             assertTextNotPresent(ACCESS_ERROR_MSG);
         else

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -1,0 +1,260 @@
+package org.labkey.test.tests.onprc_ehr;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.categories.CustomModules;
+import org.labkey.test.categories.EHR;
+import org.labkey.test.categories.ONPRC;
+import org.labkey.test.pages.issues.DetailsPage;
+import org.labkey.test.pages.issues.InsertPage;
+import org.labkey.test.pages.issues.UpdatePage;
+import org.labkey.test.util.IssuesHelper;
+import org.labkey.test.util.SqlserverOnlyTest;
+import org.labkey.test.util.TestUser;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Category({CustomModules.class, EHR.class, ONPRC.class})
+public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements SqlserverOnlyTest
+{
+    private final IssuesHelper _issuesHelper;
+
+    // constants
+    private static final TestUser USER1 = new TestUser("user1_issuetest@issues.test");
+    private static final TestUser USER2 = new TestUser("user2_issuetest@issues.test");
+    private static final TestUser ISSUE_CREATOR = new TestUser("issue_creator_issuetest@issues.test");
+    private static final TestUser FOLDER_ADMIN = new TestUser("folder_admin_issuetest@issues.test");
+
+    private static final String RESTRICTED_ISSUES_LIST = "restricted-issues";
+    private static final String UNRESTRICTED_ISSUES_LIST = "unrestricted-issues";
+    private static final String ACCESS_ERROR_MSG = "This issue is in a restricted issue list. You do not have access to this issue";
+
+    public ONPRC_RestrictedIssueTest()
+    {
+        _issuesHelper = new IssuesHelper(this);
+    }
+
+    @BeforeClass
+    public static void doSetup()
+    {
+        ONPRC_RestrictedIssueTest initTest = getCurrentTest();
+        initTest.doInit();
+    }
+
+    public void doInit()
+    {
+        _containerHelper.createProject(getProjectName(), null);
+
+        // Create test users
+        USER1.create(this).addPermission("Editor", getProjectName());
+        USER2.create(this).addPermission("Editor", getProjectName());
+        ISSUE_CREATOR.create(this).addPermission("Editor", getProjectName());
+        FOLDER_ADMIN.create(this).addPermission("Folder Administrator", getProjectName());
+
+        // Add issue list definitions
+        _issuesHelper.createNewIssuesList(RESTRICTED_ISSUES_LIST, _containerHelper, true, false, false);
+        waitAndClickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        _issuesHelper.goToAdmin();
+        _issuesHelper.setRestrictedIssueList(true);
+        _issuesHelper.setIssueAssignmentList("Site: Users");
+        clickButton("Save");
+
+        clickProject(getProjectName());
+        _issuesHelper.createNewIssuesList(UNRESTRICTED_ISSUES_LIST, _containerHelper, false, false, false);
+        waitAndClickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
+        _issuesHelper.goToAdmin();
+        _issuesHelper.setIssueAssignmentList("Site: Users");
+        clickButton("Save");
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        _userHelper.deleteUsers(false, USER1, USER2, ISSUE_CREATOR, FOLDER_ADMIN);
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList("ehr", "onprc_ehr");
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "RestrictedIssuesVerifyProject";
+    }
+
+    @Test
+    public void restrictedIssueTest()
+    {
+        clickProject(getProjectName());
+
+        // create a few issues in the restricted list
+        impersonate(ISSUE_CREATOR.getEmail());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        DetailsPage detailsPage = _issuesHelper.addIssue(String.format("Restricted issue assigned to (%s)", USER1.getUserDisplayName()), USER1.getUserDisplayName());
+        final String ISSUE_1 = detailsPage.getIssueId();
+        InsertPage insertPage = detailsPage.clickCreateNewIssue();
+        insertPage.title().set(String.format("Restricted issue assigned to (%s)", USER2.getUserDisplayName()));
+        insertPage.assignedTo().set(USER2.getUserDisplayName());
+        insertPage.save();
+        final String ISSUE_2 = insertPage.getIssueId();
+        stopImpersonating();
+
+        // verify site admins can see both issues (but not folder admins)
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyIssueAccess(ISSUE_1, true);
+        verifyIssueAccess(ISSUE_2, true);
+
+        impersonate(FOLDER_ADMIN.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyIssueAccess(ISSUE_1, false);
+        verifyIssueAccess(ISSUE_2, false);
+        stopImpersonating();
+
+        // creators can see all of the issues they opened
+        impersonate(ISSUE_CREATOR.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyIssueAccess(ISSUE_1, true);
+        verifyIssueAccess(ISSUE_2, true);
+        stopImpersonating();
+
+        // users can view issues assigned to them
+        impersonate(USER1.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyIssueAccess(ISSUE_1, true);
+        verifyIssueAccess(ISSUE_2, false);
+        stopImpersonating();
+
+        // verify notify list grants access
+        UpdatePage page = UpdatePage.beginAt(this, ISSUE_2);
+        page.notifyList().set(USER1.getEmail());
+        page.save();
+        impersonate(USER1.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyIssueAccess(ISSUE_1, true);
+        verifyIssueAccess(ISSUE_2, true);
+        stopImpersonating();
+    }
+
+    private void verifyIssueAccess(String issueID, boolean shouldHaveAccess)
+    {
+        pushLocation();
+        clickAndWait(Locator.linkContainingText(issueID));
+        if (shouldHaveAccess)
+            assertTextNotPresent(ACCESS_ERROR_MSG);
+        else
+            assertTextPresent(ACCESS_ERROR_MSG);
+        popLocation();
+    }
+
+    @Test
+    public void relatedIssueTest()
+    {
+        clickProject(getProjectName());
+
+        // create 2 issues related to each other
+        impersonate(ISSUE_CREATOR.getEmail());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        DetailsPage detailsPage = _issuesHelper.addIssue(String.format("Restricted issue assigned to (%s)", USER1.getUserDisplayName()), USER1.getUserDisplayName());
+        final String ISSUE_1 = detailsPage.getIssueId();
+        InsertPage insertPage = detailsPage.clickCreateNewIssue();
+        insertPage.title().set(String.format("Restricted issue assigned to (%s)", USER2.getUserDisplayName()));
+        insertPage.assignedTo().set(USER2.getUserDisplayName());
+        insertPage.related().set(ISSUE_1);
+        insertPage.save();
+        final String ISSUE_2 = insertPage.getIssueId();
+        stopImpersonating();
+
+        // verify creator sees both all issues and their relationships
+        impersonate(ISSUE_CREATOR.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyRelatedIssueAccess(ISSUE_1, ISSUE_2, true);
+        verifyRelatedIssueAccess(ISSUE_2, ISSUE_1, true);
+        stopImpersonating();
+
+        // verify users can open issue assigned to them but not see the related issue
+        impersonate(USER1.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyRelatedIssueAccess(ISSUE_1, ISSUE_2, false);
+        // shouldn't be able to access the other issue at all
+        verifyIssueAccess(ISSUE_2, false);
+        stopImpersonating();
+
+        impersonate(USER2.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
+        verifyRelatedIssueAccess(ISSUE_2, ISSUE_1, false);
+        verifyIssueAccess(ISSUE_1, false);
+        stopImpersonating();
+
+        // create issues in the unrestricted issue list and relate them to issues in the other list
+        impersonate(ISSUE_CREATOR.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
+        // issue related to both restricted issues
+        detailsPage = _issuesHelper.addIssue(String.format("UnRestricted issue assigned to (%s)", USER1.getUserDisplayName()),
+                USER1.getUserDisplayName(), Collections.singletonMap("related", String.join(",", List.of(ISSUE_1, ISSUE_2))));
+        final String ISSUE_3 = detailsPage.getIssueId();
+        stopImpersonating();
+
+        // any user with read access to the unrestricted list can see details but no links to the linked restricted issues
+        impersonate(FOLDER_ADMIN.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
+        verifyRelatedIssueAccess(ISSUE_3, ISSUE_1, false);
+        verifyRelatedIssueAccess(ISSUE_3, ISSUE_2, false);
+        stopImpersonating();
+
+        // users can link to the restricted issues they have access to
+        impersonate(USER1.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
+        verifyRelatedIssueAccess(ISSUE_3, ISSUE_1, true);
+        verifyRelatedIssueAccess(ISSUE_3, ISSUE_2, false);
+        stopImpersonating();
+
+        impersonate(USER2.getEmail());
+        clickProject(getProjectName());
+        clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
+        verifyRelatedIssueAccess(ISSUE_3, ISSUE_1, false);
+        verifyRelatedIssueAccess(ISSUE_3, ISSUE_2, true);
+        stopImpersonating();
+    }
+
+    private void verifyRelatedIssueAccess(String issueID, String relatedIssueID, boolean shouldHaveRelatedAccess)
+    {
+        pushLocation();
+        clickAndWait(Locator.linkContainingText(issueID));
+        Locator relatedIssueLink = Locator.linkContainingText(relatedIssueID);
+        if (shouldHaveRelatedAccess)
+        {
+            assertElementPresent(relatedIssueLink);
+            // related link should also navigate properly
+            clickAndWait(relatedIssueLink);
+            assertTextNotPresent(ACCESS_ERROR_MSG);
+        }
+        else
+        {
+            // no link but the related ID should render as text
+            assertElementNotPresent(relatedIssueLink);
+            assertTextPresent(relatedIssueID);
+        }
+        popLocation();
+    }
+}

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -65,7 +65,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         _issuesHelper.setIssueAssignmentList("Site: Users");
         clickButton("Save");
 
-        clickProject(getProjectName());
+        goToProjectHome();
         _issuesHelper.createNewIssuesList(UNRESTRICTED_ISSUES_LIST, _containerHelper, false, false, false);
         waitAndClickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
         _issuesHelper.goToAdmin();
@@ -95,7 +95,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
     @Test
     public void restrictedIssueTest()
     {
-        clickProject(getProjectName());
+        goToProjectHome();
 
         // create a few issues in the restricted list
         impersonate(ISSUE_CREATOR.getEmail());
@@ -110,13 +110,13 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         stopImpersonating();
 
         // verify site admins can see both issues (but not folder admins)
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyIssueAccess(ISSUE_1, true);
         verifyIssueAccess(ISSUE_2, true);
 
         impersonate(FOLDER_ADMIN.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyIssueAccess(ISSUE_1, false);
         verifyIssueAccess(ISSUE_2, false);
@@ -124,7 +124,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
         // creators can see all of the issues they opened
         impersonate(ISSUE_CREATOR.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyIssueAccess(ISSUE_1, true);
         verifyIssueAccess(ISSUE_2, true);
@@ -132,7 +132,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
         // users can view issues assigned to them
         impersonate(USER1.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyIssueAccess(ISSUE_1, true);
         verifyIssueAccess(ISSUE_2, false);
@@ -143,7 +143,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         page.notifyList().set(USER1.getEmail());
         page.save();
         impersonate(USER1.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyIssueAccess(ISSUE_1, true);
         verifyIssueAccess(ISSUE_2, true);
@@ -166,7 +166,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
     @Test
     public void relatedIssueTest()
     {
-        clickProject(getProjectName());
+        goToProjectHome();
 
         // create 2 issues related to each other
         impersonate(ISSUE_CREATOR.getEmail());
@@ -183,7 +183,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
         // verify creator sees both all issues and their relationships
         impersonate(ISSUE_CREATOR.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyRelatedIssueAccess(ISSUE_1, ISSUE_2, true);
         verifyRelatedIssueAccess(ISSUE_2, ISSUE_1, true);
@@ -191,7 +191,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
         // verify users can open issue assigned to them but not see the related issue
         impersonate(USER1.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyRelatedIssueAccess(ISSUE_1, ISSUE_2, false);
         // shouldn't be able to access the other issue at all
@@ -199,7 +199,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         stopImpersonating();
 
         impersonate(USER2.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(RESTRICTED_ISSUES_LIST));
         verifyRelatedIssueAccess(ISSUE_2, ISSUE_1, false);
         verifyIssueAccess(ISSUE_1, false);
@@ -207,7 +207,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
         // create issues in the unrestricted issue list and relate them to issues in the other list
         impersonate(ISSUE_CREATOR.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
         // issue related to both restricted issues
         detailsPage = _issuesHelper.addIssue(String.format("UnRestricted issue assigned to (%s)", USER1.getUserDisplayName()),
@@ -217,7 +217,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
         // any user with read access to the unrestricted list can see details but no links to the linked restricted issues
         impersonate(FOLDER_ADMIN.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
         verifyRelatedIssueAccess(ISSUE_3, ISSUE_1, false);
         verifyRelatedIssueAccess(ISSUE_3, ISSUE_2, false);
@@ -225,14 +225,14 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
         // users can link to the restricted issues they have access to
         impersonate(USER1.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
         verifyRelatedIssueAccess(ISSUE_3, ISSUE_1, true);
         verifyRelatedIssueAccess(ISSUE_3, ISSUE_2, false);
         stopImpersonating();
 
         impersonate(USER2.getEmail());
-        clickProject(getProjectName());
+        goToProjectHome();
         clickAndWait(Locator.linkContainingText(UNRESTRICTED_ISSUES_LIST));
         verifyRelatedIssueAccess(ISSUE_3, ISSUE_1, false);
         verifyRelatedIssueAccess(ISSUE_3, ISSUE_2, true);

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -152,8 +152,10 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
     private void verifyIssueAccess(String issueID, boolean shouldHaveAccess)
     {
+        Locator issueLink = Locator.linkContainingText(issueID);
+        waitForElement(issueLink, defaultWaitForPage);
         pushLocation();
-        waitAndClickAndWait(Locator.linkContainingText(issueID));
+        clickAndWait(issueLink);
         if (shouldHaveAccess)
             assertTextNotPresent(ACCESS_ERROR_MSG);
         else
@@ -239,14 +241,15 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
     private void verifyRelatedIssueAccess(String issueID, String relatedIssueID, boolean shouldHaveRelatedAccess)
     {
+        Locator issueLink = Locator.linkContainingText(issueID);
+        waitForElement(issueLink, defaultWaitForPage);
         pushLocation();
-        clickAndWait(Locator.linkContainingText(issueID));
-        Locator relatedIssueLink = Locator.linkContainingText(relatedIssueID);
+        Locator relatedIssueLink = Locator.tagWithAttributeContaining("a", "href", String.format("issues-details.view?issueId=%s", relatedIssueID));
         if (shouldHaveRelatedAccess)
         {
             assertElementPresent(relatedIssueLink);
             // related link should also navigate properly
-            waitAndClickAndWait(relatedIssueLink);
+            clickAndWait(relatedIssueLink);
             assertTextNotPresent(ACCESS_ERROR_MSG);
         }
         else

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -152,7 +152,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
 
     private void verifyIssueAccess(String issueID, boolean shouldHaveAccess)
     {
-        Locator issueLink = Locator.linkContainingText(issueID);
+        Locator issueLink = getIssueLinkLocator(issueID);
         waitForElement(issueLink, defaultWaitForPage);
         pushLocation();
         clickAndWait(issueLink);
@@ -244,7 +244,8 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         Locator issueLink = Locator.linkContainingText(issueID);
         waitForElement(issueLink, defaultWaitForPage);
         pushLocation();
-        Locator relatedIssueLink = Locator.tagWithAttributeContaining("a", "href", String.format("issues-details.view?issueId=%s", relatedIssueID));
+        clickAndWait(Locator.linkContainingText(issueID));
+        Locator relatedIssueLink = getIssueLinkLocator(relatedIssueID);
         if (shouldHaveRelatedAccess)
         {
             assertElementPresent(relatedIssueLink);
@@ -259,5 +260,10 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
             assertTextPresent(relatedIssueID);
         }
         popLocation();
+    }
+
+    private Locator getIssueLinkLocator(String issueID)
+    {
+        return Locator.tagWithAttributeContaining("a", "href", String.format("issues-details.view?issueId=%s", issueID));
     }
 }


### PR DESCRIPTION
#### Rationale
This changes how related issues are handled for restricted issues. Previously, a user was required to have access to all related issues in order to view an issues details. With this change, related issues will behave equivalently to those in an unrestricted list. A user will still be able to view the details of an issue but will not see any related issues they do not have access to (other than the ID of said related issue(s)).

This also adds automated tests to validate the desired behavior for restricted issue lists.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6302
- https://github.com/LabKey/onprcEHRModules/pull/1249
- https://github.com/LabKey/testAutomation/pull/2264
