### PR TITLE
Add nonces to <script> for ExtScheduler views

### DIFF
--- a/extscheduler/resources/views/schedulertest.html
+++ b/extscheduler/resources/views/schedulertest.html
@@ -15,13 +15,13 @@
     <link href="/ExtScheduler/Sch/ONPRC/Schedule/resources/css/sch-all-debug.css" rel="stylesheet" type="text/css" />
 
     <!--Ext JS includes-->
-    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/ext-all-debug.js" type="text/javascript"></script>
-    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/theme-classic.js" type="text/javascript"></script>
+    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/ext-all-debug.js" type="text/javascript" nonce="<%=scriptNonce%>"></script>
+    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/theme-classic.js" type="text/javascript" nonce="<%=scriptNonce%>"></script>
 
     <!--Scheduler files-->
-    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/sch-all-debug.js" type="text/javascript"></script>
+    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/sch-all-debug.js" type="text/javascript" nonce="<%=scriptNonce%>"></script>
 
-    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/examples-shared.js" type="text/javascript"></script>
+    <script src="/ExtScheduler/Sch/ONPRC/Schedule/resources/extJs/examples-shared.js" type="text/javascript" nonce="<%=scriptNonce%>"></script>
 
     <title>Simple Editor Demo</title>
   </head>

--- a/extscheduler/resources/views/weeklyTest.html
+++ b/extscheduler/resources/views/weeklyTest.html
@@ -12,14 +12,14 @@
     <!--<link href="/ExtScheduler/css/sch-all-triton.css" rel="stylesheet" type="text/css" />-->
 
     <!-- Ext JS includes -->
-    <script src="/ExtScheduler/resources/extJs/ext-all.js" type="text/javascript"></script>
-    <!--<script src="/ExtScheduler/js/ext-all-debug.js" type="text/javascript"></script>-->
-    <script src="/ExtScheduler/weekview/resources/css/theme-triton/theme-triton.js" crossorigin="anonymous" type="text/javascript"></script>
-    <!--<script src="/ExtScheduler/js/theme-triton-debug.js" crossorigin="anonymous" type="text/javascript"></script>-->
+    <script src="/ExtScheduler/resources/extJs/ext-all.js" type="text/javascript" nonce="<%=scriptNonce%>"></script>
+    <!--<script src="/ExtScheduler/js/ext-all-debug.js" type="text/javascript" nonce="<%=scriptNonce%>"></script>-->
+    <script src="/ExtScheduler/weekview/resources/css/theme-triton/theme-triton.js" crossorigin="anonymous" type="text/javascript" nonce="<%=scriptNonce%>"></script>
+    <!--<script src="/ExtScheduler/js/theme-triton-debug.js" crossorigin="anonymous" type="text/javascript" nonce="<%=scriptNonce%>"></script>-->
 
     <!-- Scheduler files -->
-    <script src="/ExtScheduler/resources/extJs/sch-all.js?ver=4.2.1" type="text/javascript"></script>
-    <!--<script src="/ExtScheduler/js/sch-all-debug.js" type="text/javascript"></script>-->
+    <script src="/ExtScheduler/resources/extJs/sch-all.js?ver=4.2.1" type="text/javascript" nonce="<%=scriptNonce%>"></script>
+    <!--<script src="/ExtScheduler/js/sch-all-debug.js" type="text/javascript" nonce="<%=scriptNonce%>"></script>-->
 
     <title>Scheduler Week View</title>
 </head>


### PR DESCRIPTION
#### Rationale
```
ContentSecurityPolicy warning on page: https://prime.ohsu.edu/extscheduler/ONPRC/ResourceScheduler/Flow%20Cytometry%20Core/weeklyTest.view?returnUrl=%2Fproject%2FONPRC%2FResourceScheduler%2FFlow%2520Cytometry%2520Core%2Fbegin.view
{
  "labkeyVersion": "24.11-SNAPSHOT",
  "csp-report": {
    "referrer": "https://prime.ohsu.edu/project/ONPRC/ResourceScheduler/Flow%20Cytometry%20Core/begin.view",
    "status-code": 200,
    "disposition": "report",
    "script-sample": "",
    "violated-directive": "script-src-elem",
    "original-policy": "default-src 'self';connect-src 'self' https://jbrowse.org https://s3.amazonaws.com https://ftp.ncbi.nlm.nih.gov https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com ;object-src 'none' ;style-src 'self' 'unsafe-inline' ;img-src 'self' data: ;font-src 'self' data: ;script-src 'unsafe-eval' 'strict-dynamic' 'nonce-2a791c4c14ff8bda';base-uri 'self' ;upgrade-insecure-requests ;frame-ancestors 'self' ;report-uri https://www.labkey.org/admin-contentsecuritypolicyreport.api?labkeyVersion=24.11-SNAPSHOT ;",
    "document-uri": "https://prime.ohsu.edu/extscheduler/ONPRC/ResourceScheduler/Flow%20Cytometry%20Core/weeklyTest.view?returnUrl=%2Fproject%2FONPRC%2FResourceScheduler%2FFlow%2520Cytometry%2520Core%2Fbegin.view",
    "effective-directive": "script-src-elem",
    "blocked-uri": "https://prime.ohsu.edu/ExtScheduler/resources/extJs/ext-all.js"
  },
  "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
}
```

#### Changes
* Add nonces