### PR TITLE
Remove CSS classes from Vet Review

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/VetReviewDisplayColumn.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/VetReviewDisplayColumn.java
@@ -66,7 +66,7 @@ public class VetReviewDisplayColumn extends DataColumn
                     text = text.replaceAll("\\*\\*", "<span style=\"background-color: yellow;\">\\*\\*</span>");
                 }
 
-                out.write("<a style=\"max-width: 500px;\" data-objectid=\"" + PageFlowUtil.filter(StringUtils.trimToNull(tokens[2])) + "\">");
+                out.write("<a style=\"max-width: 500px;\" class=\"vrdc-row\" data-objectid=\"" + PageFlowUtil.filter(StringUtils.trimToNull(tokens[2])) + "\">");
 
                 if (!_clickHandlerRegistered)
                 {

--- a/onprc_ehr/src/org/labkey/onprc_ehr/table/VetReviewDisplayColumn.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/table/VetReviewDisplayColumn.java
@@ -66,7 +66,7 @@ public class VetReviewDisplayColumn extends DataColumn
                     text = text.replaceAll("\\*\\*", "<span style=\"background-color: yellow;\">\\*\\*</span>");
                 }
 
-                out.write("<a style=\"max-width: 500px;\" class=\"labkey-text-link vrdc-row\" data-objectid=\"" + PageFlowUtil.filter(StringUtils.trimToNull(tokens[2])) + "\">");
+                out.write("<a style=\"max-width: 500px;\" data-objectid=\"" + PageFlowUtil.filter(StringUtils.trimToNull(tokens[2])) + "\">");
 
                 if (!_clickHandlerRegistered)
                 {


### PR DESCRIPTION
#### Rationale
CSS classes were added in an inline scripting refactor. These classes are on the core EHR vet review but that styling is not wanted here.

#### Changes
* Remove CSS classes
