### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/panel/EmployeeRecords.js
+++ b/ONPRC_EHR_ComplianceDB/resources/web/EHR_ComplianceDB/panel/EmployeeRecords.js
@@ -6,7 +6,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('EMPLOYEERUN', {
         requiredQC: 'Completed',
         targetQC: 'Completed',
         errorThreshold: 'ERROR',
-        successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ONPRC_EHR_ComplianceDB', 'enterData.view',(ctx ? ctx['EmployeeContainer'] : null), null),
+        successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ONPRC_EHR_ComplianceDB', 'enterData.view',(ctx ? ctx['EmployeeContainer'] : null), null),
         itemId: 'submitBtn',
         handler: function(btn){
             var panel = btn.up('ehr-dataentrypanel');
@@ -29,7 +29,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('EMPLOYEECLOSE', {
     requiredQC: 'In Progress',
     targetQC: 'In Progress',
     errorThreshold: 'WARN',
-    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ONPRC_EHR_ComplianceDB', 'enterData.view',(ctx ? ctx['EmployeeContainer'] : null), null),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ONPRC_EHR_ComplianceDB', 'enterData.view',(ctx ? ctx['EmployeeContainer'] : null), null),
     itemId: 'closeBtn',
         handler: function(btn){
             var panel = btn.up('ehr-dataentrypanel');

--- a/onprc_billing/resources/web/onprc_billing/BillingUtils.js
+++ b/onprc_billing/resources/web/onprc_billing/BillingUtils.js
@@ -60,7 +60,7 @@ ONPRC.BillingUtils = new function(){
             window.location = LABKEY.ActionURL.buildURL('onprc_billing', 'deleteBillingPeriod', null, {
                 dataRegionSelectionKey: dataRegion.name,
                 '.select': checked,
-                returnURL: window.location.pathname + window.location.search
+                returnUrl: window.location.pathname + window.location.search
             });
         },
 

--- a/onprc_billing/resources/web/onprc_billing/buttons/financeButtons.js
+++ b/onprc_billing/resources/web/onprc_billing/buttons/financeButtons.js
@@ -7,7 +7,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('FINANCESUBMIT', {
             requiredQC: 'Completed',
             targetQC: 'Completed',
             errorThreshold: 'ERROR',
-            successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.buildURL('onprc_billing', 'financeManagement.view'),
+            successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('onprc_billing', 'financeManagement.view'),
             disabled: true,
             itemId: 'submitBtn',
             handler: function(btn){

--- a/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingController.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingController.java
@@ -184,7 +184,7 @@ public class ONPRC_BillingController extends SpringActionController
         @Override
         public @NotNull URLHelper getSuccessURL(QueryForm form)
         {
-            URLHelper url = form.getReturnURLHelper();
+            URLHelper url = form.getReturnUrlHelper();
             return url != null ? url : QueryService.get().urlFor(getUser(), getContainer(), QueryAction.executeQuery, ONPRC_BillingSchema.NAME, ONPRC_BillingSchema.TABLE_INVOICE_RUNS);
         }
     }

--- a/onprc_ehr/resources/views/projectDetails.html
+++ b/onprc_ehr/resources/views/projectDetails.html
@@ -35,7 +35,7 @@
                 text: 'More Actions',
                 menu: [{
                     text: 'Edit Project Details',
-                    href: LABKEY.ActionURL.buildURL('ehr', 'dataEntryFormForQuery', null, {schemaName: 'ehr', queryName: 'project', project: project}) + '&returnUrl=' + LDK.Utils.getSrcURL()
+                    href: LABKEY.ActionURL.buildURL('ehr', 'dataEntryFormForQuery', null, {schemaName: 'ehr', queryName: 'project', project: project}) + '&returnUrl=' + LDK.Utils.getReturnUrl()
                 }]
             }]
         }

--- a/onprc_ehr/resources/views/protocolDetails.html
+++ b/onprc_ehr/resources/views/protocolDetails.html
@@ -103,7 +103,7 @@ Ext4.onReady(function (){
             text: 'More Actions',
             menu: [{
                 text: 'Edit Protocol Details',
-                href: LABKEY.ActionURL.buildURL('ehr', 'dataEntryFormForQuery', null, {schemaName: 'ehr', queryName: 'protocol', protocol: protocol}) + '&returnUrl=' + LDK.Utils.getSrcURL()
+                href: LABKEY.ActionURL.buildURL('ehr', 'dataEntryFormForQuery', null, {schemaName: 'ehr', queryName: 'protocol', protocol: protocol}) + '&returnUrl=' + LDK.Utils.getReturnUrl()
             }]
         }]
     }

--- a/onprc_ehr/resources/web/onprc_ehr/buttons/bulkEditRequestButtons.js
+++ b/onprc_ehr/resources/web/onprc_ehr/buttons/bulkEditRequestButtons.js
@@ -75,14 +75,14 @@ ONPRC_EHR.Buttons.bulkEditRequestHandler = function(dataRegionName, formType, is
 
             function viewForm(keys){
                 var re = new RegExp('^' + window.location.origin);
-                var srcURL = window.location.href.replace(re, '');
+                var returnUrl = window.location.href.replace(re, '');
 
                 if (keys.length < 10){
-                    window.location = LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm', null, {formType: formType, pkValues: keys.join(';'), srcURL: srcURL});
+                    window.location = LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm', null, {formType: formType, pkValues: keys.join(';'), returnUrl: returnUrl});
                 }
                 else {
                     var newForm = Ext4.DomHelper.append(document.getElementsByTagName('body')[0],
-                            '<form method="POST" action="' + LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm', null, {formType: formType, srcURL: srcURL}) + '">' +
+                            '<form method="POST" action="' + LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm', null, {formType: formType, returnUrl: returnUrl}) + '">' +
                                 '<input type="hidden" name="pkValues" value="' + Ext4.htmlEncode(keys.join(';')) + '" />' +
                             '<input type="hidden" name="X-LABKEY-CSRF" value="' + Ext4.htmlEncode(LABKEY.CSRF) + '" />' +
                             '</form>');

--- a/onprc_ehr/resources/web/onprc_ehr/buttons/labworkButtons.js
+++ b/onprc_ehr/resources/web/onprc_ehr/buttons/labworkButtons.js
@@ -137,7 +137,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('LABWORK_SUBMIT', {
     requiredQC: 'Completed',
     targetQC: 'Completed',
     errorThreshold: 'INFO',
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'submitBtn',
     handler: function(btn){

--- a/onprc_ehr/resources/web/onprc_ehr/model/sources/Menses.js
+++ b/onprc_ehr/resources/web/onprc_ehr/model/sources/Menses.js
@@ -23,7 +23,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('MENSEFINAL', {
     requiredQC: 'Completed',
     targetQC: 'Completed',
     errorThreshold: 'INFO',
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'finalBtn',
     handler: function(btn){

--- a/onprc_ehr/resources/web/onprc_ehr/panel/LockAnimalsPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/LockAnimalsPanel.js
@@ -187,7 +187,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('BIRTHARRIVALCLOSE', {
     name: 'closeBtn',
     requiredQC: 'In Progress',
     errorThreshold: 'WARN',
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'closeBtn1',
     handler: function(btn){
@@ -214,8 +214,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('BIRTHARRIVALFINAL', {
     requiredQC: 'Completed',
     targetQC: 'Completed',
     errorThreshold: 'WARN',
-    //successURL: LABKEY.ActionURL.buildURL('ehr', 'dataEntryForm.view', null, {formType: LABKEY.ActionURL.getParameter('formType')}),
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'submitBtn',
     handler: function(btn){
@@ -286,7 +285,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('BIRTHARRIVALREVIEW', {
     requiredQC: 'Review Required',
     targetQC: 'Review Required',
     errorThreshold: 'WARN',
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'reviewBtn1',
     handler: function(btn){

--- a/onprc_ehr/resources/web/onprc_ehr/window/BehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/BehaviorCasesWindow.js
@@ -211,7 +211,7 @@ Ext4.define('EHR.window.BehaviorCasesWindow', {
 EHR.DataEntryUtils.registerDataEntryFormButton('BEHAVIOR_CASES', {
     text: 'Close/Review Cases',
     name: 'behaviorCase',
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('ehr', 'enterData.view'),
     disabled: true,
     itemId: 'behaviorCase',
     requiredPermissions: [

--- a/onprc_ehr/resources/web/onprc_ehr/window/CreateProjectWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/CreateProjectWindow.js
@@ -76,7 +76,7 @@ Ext4.define('ONPRC_EHR.window.CreateProjectWindow', {
                             };
 
                             var newForm = Ext4.DomHelper.append(document.getElementsByTagName('body')[0],
-                                            '<form method="POST" action="' + LABKEY.ActionURL.buildURL('ehr', 'dataEntryFormForQuery', null, {schemaName: 'ehr', queryName: 'project', project: ''}) + '&returnUrl=' + LDK.Utils.getSrcURL() + '">' +
+                                            '<form method="POST" action="' + LABKEY.ActionURL.buildURL('ehr', 'dataEntryFormForQuery', null, {schemaName: 'ehr', queryName: 'project', project: ''}) + '&returnUrl=' + LDK.Utils.getReturnUrl() + '">' +
                                             '<input type="hidden" name="initialData" value="' + Ext4.htmlEncode(Ext4.encode(initialData)) + '" />' +
                                             '<input type="hidden" name="X-LABKEY-CSRF" value="' + Ext4.htmlEncode(LABKEY.CSRF) + '" />' +
                                             '</form>');

--- a/onprc_ehr/resources/web/onprc_ehr/window/EnvironmentalRecords.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/EnvironmentalRecords.js
@@ -6,8 +6,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('ENV_RUN', {
         requiredQC: 'Completed',
         targetQC: 'Completed',
         errorThreshold: 'ERROR',
-        // successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ONPRC_EHR', 'EnvironmentalenterData.view',(ctx ? ctx['EHRStudyContainer'] : null), null),
-    successURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('onprc_ehr', 'EnvironmentalenterData.view'),
+        successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('onprc_ehr', 'EnvironmentalenterData.view'),
         itemId: 'submitBtn',
         handler: function(btn){
             var panel = btn.up('ehr-dataentrypanel');
@@ -30,8 +29,7 @@ EHR.DataEntryUtils.registerDataEntryFormButton('ENV_CLOSE', {
     requiredQC: 'In Progress',
     targetQC: 'In Progress',
     errorThreshold: 'WARN',
-    // successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('ONPRC_EHR', 'EnvironmentalenterData.view',(ctx ? ctx['EHRStudyContainer'] : null), null),
-    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.getParameter('returnURL') || LABKEY.ActionURL.buildURL('onprc_ehr', 'EnvironmentalenterData.view'),
+    successURL: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('onprc_ehr', 'EnvironmentalenterData.view'),
     itemId: 'closeBtn',
         handler: function(btn){
             var panel = btn.up('ehr-dataentrypanel');


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters