### PR TITLE
Remove unnecessary QueryWebPart renders

### DIFF
--- a/onprc_ehr/resources/views/NIHRateSheet.html
+++ b/onprc_ehr/resources/views/NIHRateSheet.html
@@ -25,7 +25,6 @@
         title: 'NIH Rate Sheet'
     };
     var wp= new LABKEY.QueryWebPart(config);
-    wp.render();
 </script>
 </body>
 </html>

--- a/sla/resources/views/censusBulkEdit.html
+++ b/sla/resources/views/censusBulkEdit.html
@@ -33,7 +33,6 @@
             ]
         }
     });
-    wp.render();
     });
 </script>
 


### PR DESCRIPTION
#### Rationale
If `renderTo` is defined in a QueryWebPart config, it is automatically rendered. Calling `render()` explicitly will request the data again and re-render the grid. This is inefficient at best but I suspect this re-render is behind some intermittent failures we've been seeing on TeamCity.
I'm cleaning up all that I could find.

#### Related Pull Requests
* N/A

#### Changes
* Remove unnecessary QueryWebPart renders