### PR TITLE
24.11 fb reduced f&a update

### DIFF
--- a/onprc_billing/resources/queries/onprc_billing/perDiemRates_RateCalc.sql
+++ b/onprc_billing/resources/queries/onprc_billing/perDiemRates_RateCalc.sql
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2013 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+--PARAMETERS(EndDate TIMESTAMP)
+
+SELECT
+  p.id,
+  p.date,
+  p.project,
+  alias.alias as account,
+  p.chargeId,
+  p.chargeId.departmentCode as serviceCenter,
+  p.categories,
+  p.startDate,
+  p.chargeId.name as item,
+  p.chargeId.category as category,
+  p.housingRecords as sourceRecord,
+  alias.budgetstartdate as GrantStart,
+  alias.farate,
+  RateCalc2025(alias.alias,p.chargeID,p.project, alias.budgetstartdate,alias.farate) as unitCost
+
+
+
+FROM onprc_billing.perDiems p
+
+LEFT JOIN onprc_billing_public.chargeRates cr ON (
+    CAST(p.date AS DATE) >= CAST(cr.startDate AS DATE) AND
+    (CAST(p.date AS DATE) <= cr.enddateCoalesced OR cr.enddate IS NULL) AND
+    p.chargeId = cr.chargeId
+)
+
+LEFT JOIN onprc_billing_public.projectAccountHistory aliasAtTime ON (
+    aliasAtTime.project = p.project AND
+    aliasAtTime.startDate <= cast(p.date as date) AND
+    aliasAtTime.endDate >= cast(p.date as date)
+    )
+LEFT JOIN onprc_billing_public.aliases alias ON (
+  aliasAtTime.account = alias.alias
+)
+
+LEFT JOIN onprc_billing_public.projectMultipliers pm ON (
+    CAST(p.date AS DATE) >= CASt(pm.startDate AS DATE) AND
+    (CAST(p.date AS DATE) <= pm.enddateCoalesced OR pm.enddate IS NULL) AND
+    alias.alias = pm.account
+)
+Where p.id.demographics.species Not IN ('Rabbit','Guinea Pig')

--- a/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-25.001-25.002.sql
+++ b/onprc_billing/resources/schemas/dbscripts/sqlserver/onprc_billing-25.001-25.002.sql
@@ -1,0 +1,144 @@
+CREATE FUNCTION [onprc_ehr].[RateCalc2025]
+    (
+    @alias varchar(20),
+    @chargeId float,
+    @project float,
+    @startDate date,
+    @GrantDate date,
+    @baseSubsidyVal float  -- This parameter may be deprecated but kept for compatibility
+    )
+    RETURNS float
+    AS
+BEGIN
+    Declare @unitCostVal float,
+        @projectExemption float,
+        @projectMultipler float,
+        @unitCost float,
+        @NonOGAAlias varchar(20),
+        @blankAliasType varchar(20),
+        @baseSubsidy float,
+        @GrantDate Date,
+        @subsidy float,
+        @faRate float,
+        @removeSubsidy smallInt,
+        @aliasRaiseFA smallInt,
+        @chargeRaiseFA smallInt
+
+    -- Retrieve the grant's budget start date
+
+
+-- Determine base subsidy based on grant date
+SET @baseSubsidy = CASE
+        WHEN @GrantDate > '2024-07-01' THEN 0.475
+        ELSE 0.47
+END;
+
+    -- Use the calculated base subsidy instead of the input parameter
+    SET @subsidy = @baseSubsidy;
+
+    -- Rest of the function logic remains with corrections...
+
+    -- Determine project exemption
+    SET @projectExemption = (
+        SELECT cr.unitcost
+        FROM onprc_billing.chargeRateExemptions cr
+        WHERE cr.chargeId = @chargeId
+            AND cr.project = @project
+            AND cr.startDate < @startDate
+            AND (@startDate <= cr.endDate OR cr.enddate IS NULL)
+    );
+
+    -- Determine project multiplier
+    SET @projectMultipler = (
+        SELECT pm.multiplier
+        FROM onprc_billing.projectMultipliers pm
+        WHERE pm.account = @alias
+            AND pm.startdate <= @startDate
+            AND (pm.enddate >= @startDate OR pm.enddate IS NULL)
+    );
+
+    -- Check for non-OGA alias
+    SET @NonOGAAlias = (
+        SELECT a.category
+        FROM onprc_billing.aliases a
+        WHERE a.alias = @alias
+            AND a.budgetStartDate <= @startDate
+            AND a.budgetEndDate >= @startDate
+    );
+
+    -- Check for blank alias type
+    SET @blankAliasType = (
+        SELECT a.aliasType
+        FROM onprc_billing.aliases a
+        WHERE a.alias = @alias
+            AND a.budgetStartDate <= @startDate
+            AND a.budgetEndDate >= @startDate
+    );
+
+    -- Determine if subsidy should be removed
+    SET @removeSubsidy = (
+        SELECT t.removeSubsidy
+        FROM onprc_billing.aliases a
+        JOIN onprc_billing.aliasTypes t ON a.aliasType = t.aliasType
+        WHERE a.alias = @alias
+            AND a.budgetStartDate <= @startDate
+            AND a.budgetEndDate >= @startDate
+    );
+
+    -- Check if charge can raise F&A
+    SET @chargeRaiseFA = (
+        SELECT c.canRaiseFA
+        FROM onprc_billing.chargeableItems c
+        JOIN onprc_billing.chargeRates cr ON c.rowId = cr.chargeId
+        WHERE cr.chargeId = @chargeId
+            AND cr.StartDate <= @startDate
+            AND (cr.EndDate >= @startDate OR cr.EndDate IS NULL)
+    );
+
+    -- Check if alias can raise F&A
+    SET @aliasRaiseFA = (
+        SELECT t.canRaiseFA
+        FROM onprc_billing.aliases a
+        JOIN onprc_billing.aliasTypes t ON a.aliasType = t.aliasType
+        WHERE a.alias = @alias
+            AND a.budgetStartDate <= @startDate
+            AND a.budgetEndDate >= @startDate
+    );
+
+    -- Get F&A rate for alias
+    SET @faRate = (
+        SELECT a.faRate
+        FROM onprc_billing.aliases a
+        WHERE a.alias = @alias
+            AND a.budgetStartDate <= @startDate
+            AND a.budgetEndDate >= @startDate
+    );
+
+    -- Get base unit cost
+    SET @unitCost = (
+        SELECT r.unitcost
+        FROM onprc_billing.chargeRates r
+        WHERE r.chargeID = @chargeId
+            AND r.startDate <= @startDate
+            AND (r.enddate >= @startDate OR r.enddate IS NULL)
+    );
+
+    -- Calculate final unit cost
+    SET @unitCostVal = CASE
+        WHEN @projectExemption IS NOT NULL THEN @projectExemption
+        WHEN @projectMultipler IS NOT NULL THEN @projectMultipler * @unitCost
+        WHEN @unitCost IS NULL THEN NULL
+        WHEN @NonOGAAlias IS NOT NULL AND @NonOGAAlias != 'OGA' THEN @unitCost
+        WHEN @blankAliasType IS NULL THEN NULL
+        WHEN (@removeSubsidy = 1 AND (@aliasRaiseFA = 1 AND @chargeRaiseFA = 1)) THEN
+            ((@unitCost / (1 - @subsidy)) * (CASE WHEN @faRate < @baseSubsidy THEN (1 + @baseSubsidy) ELSE 1 END)
+        WHEN (@removeSubsidy = 1 AND @aliasRaiseFA = 0) THEN
+            (@unitCost / (1 - @subsidy))
+        WHEN (@removeSubsidy = 0 AND (@aliasRaiseFA = 1 AND @chargeRaiseFA = 1)) THEN
+            (@unitCost * (CASE WHEN @faRate = 0 THEN (1 + @subsidy) ELSE 1 END))
+        ELSE @unitCost
+    END;
+
+    RETURN @unitCostVal;
+END
+GO

--- a/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingModule.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingModule.java
@@ -82,7 +82,7 @@ public class ONPRC_BillingModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 23.004;
+        return 25.003;
     }
 
     @Override

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
@@ -32,6 +32,7 @@ import java.util.Map;
  * User: bimber
  * Date: 9/21/13
  * Time: 9:55 AM
+ * Update to adjust Base Subsidy
  */
 public class ONPRC_EHRManager
 {

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
@@ -81,7 +81,7 @@ public class ONPRC_EHRManager
     @Queryable
     public static final String NURSERY_AREA = "Nursery Area";
     @Queryable
-    public static final Double BASE_SUBSIDY = 0.47;
+    public static final Double BASE_SUBSIDY = 0.475; /*Update based on july1,2024 request*/
 
     @Queryable
     public static final String CAGE_HEIGHT_EXEMPTION_FLAG = "Obese, or Pregnant";

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
@@ -82,7 +82,7 @@ public class ONPRC_EHRManager
     @Queryable
     public static final String NURSERY_AREA = "Nursery Area";
     @Queryable
-    public static final Double BASE_SUBSIDY = 0.475; /*Update based on july1,2024 request*/
+    public static final Double BASE_SUBSIDY = 0.475; /* Change requested in Finance Issue 10689 */
 
     @Queryable
     public static final String CAGE_HEIGHT_EXEMPTION_FLAG = "Obese, or Pregnant";

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
@@ -82,7 +82,7 @@ public class ONPRC_EHRManager
     @Queryable
     public static final String NURSERY_AREA = "Nursery Area";
     @Queryable
-    public static final Double BASE_SUBSIDY = 0.475; /* Change requested in Finance Issue 10689 */
+    public static final Double BASE_SUBSIDY = 0.475; /* Update requested in Finance Issue 10689 */
 
     @Queryable
     public static final String CAGE_HEIGHT_EXEMPTION_FLAG = "Obese, or Pregnant";


### PR DESCRIPTION
#### Rationale
There is a need to handle base subsidy based on Grant date and using the Rate Calc function and modifying it for that allows a 1 line of code to replace the code currently in per diem rate query from lines 37 to line 61
This calculation is used in all queries used to produce unit cost for charges.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
perdiem_RatesCalc.sql
onprc-billing-25.001-25.002 which created RateCalc2025 (the new function0
