### PR TITLE
Make Id not editable in BSU Rounds

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/model/sources/BehaviorRounds.js
+++ b/onprc_ehr/resources/web/onprc_ehr/model/sources/BehaviorRounds.js
@@ -1,0 +1,54 @@
+
+EHR.model.DataModelManager.registerMetadata('BehaviorRounds', {
+    allQueries: {
+        performedby: {
+            lookup: {
+                schemaName: 'core',
+                queryName: 'users',
+                keyColumn: 'DisplayName',
+                displayColumn: 'DisplayName',
+                columns: 'UserId,DisplayName,FirstName,LastName',
+                sort: 'Type,DisplayName'
+            },
+            editorConfig: {
+                anyMatch: true,
+                listConfig: {
+                    innerTpl: '{[LABKEY.Utils.encodeHtml(values.DisplayName + (values.LastName ? " (" + values.LastName + (values.FirstName ? ", " + values.FirstName : "") + ")" : ""))]}',
+                    getInnerTpl: function(){
+                        return this.innerTpl;
+                    }
+                }
+            }
+        }
+    },
+    byQuery: {
+        'study.clinremarks': {
+            s: {
+                hidden: true
+            },
+            o: {
+                hidden: true
+            },
+            a: {
+                hidden: true
+            },
+            p: {
+                hidden: true
+            },
+            remark: {
+                columnConfg: {
+                    width: 360
+                },
+                height: 60
+            }
+        },
+        'study.clinical_observations': {
+            Id: {
+                editable: false,
+                columnConfig: {
+                    editable: false
+                }
+            }
+        }
+    }
+});

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/BehaviorRoundsFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/BehaviorRoundsFormType.java
@@ -54,7 +54,7 @@ public class BehaviorRoundsFormType extends TaskForm
         //Created the ONPRC version .js file to add default value for the amount units field by Kollil on 12/1923
         //Refer to tkt # 10285
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/model/sources/BehaviorDefaults.js"));
-        addClientDependency(ClientDependency.supplierFromPath("ehr/model/sources/BehaviorRounds.js"));
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/model/sources/BehaviorRounds.js"));
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/BehaviorCasesWindow.js"));
     }
 

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
@@ -1743,6 +1743,8 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         waitForElementToDisappear(caseWindow);
         obsGrid.waitForRowCount(1);
         Assert.assertEquals("Alopecia Score", obsGrid.getFieldValue(1, "category"));
+        Assert.assertEquals("Id field should not be editable.", "on", obsGrid.getCell(1, "Id")
+                .findElement(getDriver()).findElement(By.tagName("div")).getDomAttribute("unselectable"));
         String observation = (String)obsGrid.getFieldValue(1, "observation");
         Assert.assertTrue("Expected \"Observation/Score\" to be empty (blank or null) but was \"" + observation + "\"", StringUtils.isEmpty(observation));
         Assert.assertEquals(SUBJECTS[0], obsGrid.getFieldValue(1, "Id"));


### PR DESCRIPTION
#### Rationale
The Id comes from selecting open cases and should not be editable to ensure the observation animal Ids are aligned with the case animal Ids.

#### Changes
* Copy BehaviorRounds from ehr into onprc_ehr
* Update clinical_obs to make Id not editable
* Add check in test