### PR TITLE
Remove code that was originally set up for "Breeder Lock Release Grou…

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/panel/LockAnimalsPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/LockAnimalsPanel.js
@@ -142,26 +142,11 @@ Ext4.define('ONPRC_EHR.panel.LockAnimalsPanel', {
                     item.setDisabled(locked); ///Disable all data entry fields on the screen
                     btn.setDisabled(locked); //Disable the "Unlock Entry" button for other users
 
-                    //Let the sys Admins and Folder Admins unlock the screen
-                    if (LABKEY.Security.currentUser.isSystemAdmin || LABKEY.Security.currentUser.isAdmin )
+                    if (LABKEY.Security.currentUser.isSystemAdmin || LABKEY.Security.currentUser.isAdmin )  //Let the sys Admins and Folder Admins unlock the screen
                     {
                         btn.setDisabled(!locked);
                     }
-                    else {
-                        //Allow specific permission group to unlock birth screen
-                        var groups = "Birth Lock Release Group";
-                        LABKEY.Security.getGroupsForCurrentUser({
-                            successCallback: function (results) {
-                                for (var i = 0; i < results.groups.length; i++) {
-                                    if (groups == (results.groups[i].name)) {
 
-                                        btn.setDisabled(!locked);
-                                        return true;
-                                    }
-                                }
-                            }
-                        });
-                    }
                 }
                 //If the locked person is the loggedin person, Lock the screen. ie the Birth screen is always locked when you open it first time.
                 else if (this.locked_person == LABKEY.Security.currentUser.displayName)  // || LABKEY.Security.currentUser.isAdmin )


### PR DESCRIPTION
Modified program to remove code that allowed Admin permission group to remove a "lock" onto Birth screen when
a current user has exclusive access to the birth screen.  The permission Group is Called "Birth Lock Release Group".
