### PR TITLE
Add case number to all cases

### DIFF
--- a/onprc_ehr/resources/queries/study/Cases.query.xml
+++ b/onprc_ehr/resources/queries/study/Cases.query.xml
@@ -1,0 +1,64 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="cases" tableDbType="TABLE">
+                <tableUrl></tableUrl>
+                <insertUrl />
+                <importUrl />
+                <updateUrl />
+                <deleteUrl />
+                <columns>
+                    <column columnName="date">
+                        <columnTitle>Open Date</columnTitle>
+                        <formatString>Date</formatString>
+                    </column>
+                    <column columnName="caseNo">
+                        <columnTitle>Case Number</columnTitle>
+                    </column>
+                    <column columnName="enddate">
+                        <columnTitle>Close Date</columnTitle>
+                        <isHidden>false</isHidden>
+                    </column>
+                    <column columnName="reviewdate">
+                        <columnTitle>Next Review Date</columnTitle>
+                    </column>
+                    <column columnName="category">
+                        <columnTitle>Case Category</columnTitle>
+                        <isUserEditable>false</isUserEditable>
+                        <nullable>false</nullable>
+                    </column>
+                    <column columnName="assignedvet">
+                        <columnTitle>Assigned Vet</columnTitle>
+                        <fk>
+                            <fkDbSchema>ehr_lookups</fkDbSchema>
+                            <fkTable>veterinarians</fkTable>
+                            <fkColumnName>UserId</fkColumnName>
+                            <fkDisplayColumnName>DisplayName</fkDisplayColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="problem">
+                        <columnTitle>Master Problem(s)</columnTitle>
+                    </column>
+                    <column columnName="reviewfrequency">
+                        <columnTitle>Review Frequency</columnTitle>
+                    </column>
+                    <column columnName="remark">
+                        <columnTitle>Description/Notes</columnTitle>
+                        <inputType>textarea</inputType>
+                    </column>
+                    <column columnName="plan">
+                        <columnTitle>P2</columnTitle>
+                        <inputType>textarea</inputType>
+                        <isHidden>true</isHidden>
+                    </column>
+                    <column columnName="performedby">
+                        <columnTitle>Opened By</columnTitle>
+                    </column>
+                    <column columnName="project">
+                        <isHidden>true</isHidden>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/onprc_ehr/resources/queries/study/cases.js
+++ b/onprc_ehr/resources/queries/study/cases.js
@@ -1,0 +1,10 @@
+
+require("ehr/triggers").initScript(this);
+var triggerHelper = new org.labkey.onprc_ehr.query.ONPRC_EHRTriggerHelper(LABKEY.Security.currentUser.id, LABKEY.Security.currentContainer.id);
+
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_INSERT, 'study', 'Cases', function(helper, errors, row, oldRow){
+    // Fill in case number on case insert
+    if (!helper.isValidateOnly() && !helper.isETL() && !row.caseNo){
+        row.caseNo = triggerHelper.getNextCaseDisplayId();
+    }
+});

--- a/onprc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
+++ b/onprc_ehr/resources/referenceStudy/study/datasets/datasets_metadata.xml
@@ -520,6 +520,9 @@
             <column columnName="problem">
                 <datatype>varchar</datatype>
             </column>
+            <column columnName="caseNo">
+                <datatype>integer</datatype>
+            </column>
         </columns>
         <tableTitle>Cases</tableTitle>
     </table>

--- a/onprc_ehr/resources/views/ehrAdmin.html
+++ b/onprc_ehr/resources/views/ehrAdmin.html
@@ -22,7 +22,8 @@ Ext4.onReady(function (){
                 {name: 'Verify Dataset Columns', url: '<%=contextPath%><%=containerPath%>/ehr-validateDataSetCols.view'},
                 {name: 'Verify EHR Schema Indexes Are Compressed', url: '<%=contextPath%><%=containerPath%>/ehr-ensureEHRSchemaIndexes.view'},
                 {name: 'Cache Demographics On All Living Animals', url: '<%=contextPath%><%=containerPath%>/ehr-cacheLivingAnimals.view'},
-                {name: 'Prime/Refresh Data Entry Cache', url: '<%=contextPath%><%=containerPath%>/ehr-primeDataEntryCache.view'}
+                {name: 'Prime/Refresh Data Entry Cache', url: '<%=contextPath%><%=containerPath%>/ehr-primeDataEntryCache.view'},
+                {name: 'Populate Case Numbers', url: '<%=contextPath%><%=containerPath%>/onprc_ehr-populateCaseNo.view'}
             ]
         },{
             header: 'Logs',

--- a/onprc_ehr/resources/views/populateCaseNo.html
+++ b/onprc_ehr/resources/views/populateCaseNo.html
@@ -1,0 +1,37 @@
+<script type="text/javascript" nonce="<%=scriptNonce%>">
+    LABKEY.Utils.onReady(function () {
+        const el = document.getElementById('populate');
+        el['onclick'] = function () { populateCaseNumbers(el); };
+    });
+
+    function populateCaseNumbers() {
+        const output = document.getElementById("output");
+        output.innerHTML = "Starting. See site log for batch counts."
+
+        LABKEY.Ajax.request({
+            url : LABKEY.ActionURL.buildURL('onprc_ehr', 'populateCaseNumbers'),
+            method : 'POST',
+            scope: this,
+            failure: LABKEY.Utils.getCallbackWrapper((response) => {
+                const output = document.getElementById("output");
+                output.innerHTML += `<br><br>${response.exception}`;
+            }),
+            success: LABKEY.Utils.getCallbackWrapper((result) => {
+                const output = document.getElementById("output");
+                if (result.rows && result.rows > 0) {
+                    output.innerHTML += `<br><br>Successfully populated ${result.rows} case numbers.`
+                } else {
+                    output.innerHTML += `<br><br>No cases found missing caseNo.`
+                }
+            })
+        });
+    }
+</script>
+
+<div>
+    <button id="populate">Populate Case Numbers</button>
+    <br><br>
+    <p>
+        <span id="output"></span>
+    </p>
+</div>

--- a/onprc_ehr/resources/views/populateCaseNo.view.xml
+++ b/onprc_ehr/resources/views/populateCaseNo.view.xml
@@ -1,0 +1,5 @@
+<view xmlns="http://labkey.org/data/xml/view" title="Populate Empty Case Numbers">
+    <dependencies>
+        <dependency path="ehr.context" />
+    </dependencies>
+</view>

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
@@ -28,36 +28,52 @@ import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.Sort;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.security.EHRDataEntryPermission;
+import org.labkey.api.exp.property.Domain;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.security.AdminConsoleAction;
+import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.study.Dataset;
+import org.labkey.api.study.DatasetTable;
+import org.labkey.api.study.StudyService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.NavTree;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * User: bbimber
@@ -510,6 +526,106 @@ public class ONPRC_EHRController extends SpringActionController
         public void setStartingId(Integer startingId)
         {
             _startingId = startingId;
+        }
+    }
+
+    @RequiresPermission(EHRDataEntryPermission.class)
+    public class PopulateCaseNumbersAction extends MutatingApiAction<Object>
+    {
+        private String _casesProvisionedName;
+
+        @Override
+        public void validateForm(Object o, Errors errors)
+        {
+            super.validateForm(o, errors);
+
+            StudyService ss = StudyService.get();
+            if (ss == null)
+            {
+                errors.reject(ERROR_REQUIRED, "No study");
+                return;
+            }
+
+            int datasetId = ss.getDatasetIdByName(getContainer(), "cases");
+            Dataset dataset = ss.getDataset(getContainer(), datasetId);
+
+            if (dataset == null)
+            {
+                errors.reject(ERROR_REQUIRED, "Cases dataset not found.");
+                return;
+            }
+
+            Domain domain = dataset.getDomain();
+            if (domain == null)
+            {
+                errors.reject(ERROR_REQUIRED, "Cases dataset domain not found.");
+                return;
+            }
+
+            _casesProvisionedName = domain.getStorageTableName();
+            if (_casesProvisionedName == null)
+            {
+                errors.reject(ERROR_REQUIRED, "Cases dataset provisioned name not found.");
+            }
+        }
+
+        @Override
+        public ApiResponse execute(Object form, BindException errors) throws SQLException
+        {
+            Container c = EHRService.get().getEHRStudyContainer(getContainer());
+            TableInfo ti = QueryService.get().getUserSchema(getUser(), c, "study").getTable("cases");
+
+            SQLFragment sql = new SQLFragment("UPDATE c SET c.caseNo = updates.caseNo FROM studydataset." + _casesProvisionedName + " c JOIN (VALUES ");
+
+            logger.info("Starting case number updates.");
+
+            SimpleFilter filter = SimpleFilter.createContainerFilter(getContainer());
+            filter.addCondition(FieldKey.fromParts("caseNo"), null, CompareType.ISBLANK);
+            ResultSet rs = new TableSelector(ti, filter, new Sort("date")).getResultSet(false, false);
+            boolean newBatch = true;
+            int counter = 0;
+            while( rs.next() )
+            {
+                if (newBatch) {
+                    newBatch = false;
+                }
+                else {
+                    sql.append(",");
+                }
+                sql.append("(?, ?)");
+                sql.add(rs.getInt("dsrowid"));
+                sql.add(ONPRC_EHRManager.get().getNextCaseNo(c));
+                counter++;
+
+                if (counter % 5000 == 0)
+                {
+                    newBatch = true;
+                    sql.append(") AS updates(dsrowid, caseNo) ");
+                    sql.append("ON c.dsrowid = updates.dsrowid");
+
+                    new SqlExecutor(ti.getSchema()).execute(sql);
+
+                    logger.info(counter + " case numbers added.");
+
+                    sql = new SQLFragment("UPDATE c SET c.caseNo = updates.caseNo FROM studydataset." + _casesProvisionedName + " c JOIN (VALUES ");
+                }
+            }
+
+            if (!newBatch)
+            {
+                sql.append(") AS updates(dsrowid, caseNo) ");
+                sql.append("ON c.dsrowid = updates.dsrowid");
+                new SqlExecutor(ti.getSchema()).execute(sql);
+            }
+
+            JSONObject ret = new JSONObject();
+            ret.put("rows", counter);
+            ret.put("success", true);
+
+            logger.info("Case number update completed. " + counter + " case numbers updated in total.");
+
+
+            return new ApiSimpleResponse(ret);
         }
     }
 }

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
@@ -579,11 +579,14 @@ public class ONPRC_EHRController extends SpringActionController
 
             logger.info("Starting case number updates.");
 
+            // Stream cases with no case number, sorted by date
             SimpleFilter filter = SimpleFilter.createContainerFilter(getContainer());
             filter.addCondition(FieldKey.fromParts("caseNo"), null, CompareType.ISBLANK);
             ResultSet rs = new TableSelector(ti, filter, new Sort("date")).getResultSet(false, false);
+
             boolean newBatch = true;
             int counter = 0;
+
             while( rs.next() )
             {
                 if (newBatch) {
@@ -597,6 +600,7 @@ public class ONPRC_EHRController extends SpringActionController
                 sql.add(ONPRC_EHRManager.get().getNextCaseNo(c));
                 counter++;
 
+                // Batch boundary
                 if (counter % 5000 == 0)
                 {
                     newBatch = true;
@@ -605,7 +609,7 @@ public class ONPRC_EHRController extends SpringActionController
 
                     new SqlExecutor(ti.getSchema()).execute(sql);
 
-                    logger.info(counter + " case numbers added.");
+                    logger.info(counter + " total case numbers added.");
 
                     sql = new SQLFragment("UPDATE c SET c.caseNo = updates.caseNo FROM studydataset." + _casesProvisionedName + " c JOIN (VALUES ");
                 }
@@ -622,7 +626,7 @@ public class ONPRC_EHRController extends SpringActionController
             ret.put("rows", counter);
             ret.put("success", true);
 
-            logger.info("Case number update completed. " + counter + " case numbers updated in total.");
+            logger.info("Case number update completed. " + counter + " total case numbers updated.");
 
 
             return new ApiSimpleResponse(ret);

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
@@ -575,7 +575,12 @@ public class ONPRC_EHRController extends SpringActionController
             Container c = EHRService.get().getEHRStudyContainer(getContainer());
             TableInfo ti = QueryService.get().getUserSchema(getUser(), c, "study").getTable("cases");
 
-            SQLFragment sql = new SQLFragment("UPDATE c SET c.caseNo = updates.caseNo FROM studydataset." + _casesProvisionedName + " c JOIN (VALUES ");
+            SQLFragment sqlStart = new SQLFragment("UPDATE c SET c.caseNo = updates.caseNo FROM studydataset.");
+            sqlStart.appendIdentifier(_casesProvisionedName);
+            sqlStart.append(" c JOIN (VALUES ");
+
+            SQLFragment sqlEnd = new SQLFragment(") AS updates(dsrowid, caseNo) ");
+            sqlEnd.append("ON c.dsrowid = updates.dsrowid");
 
             logger.info("Starting case number updates.");
 
@@ -586,6 +591,7 @@ public class ONPRC_EHRController extends SpringActionController
 
             boolean newBatch = true;
             int counter = 0;
+            SQLFragment sql = new SQLFragment().append(sqlStart);
 
             while( rs.next() )
             {
@@ -604,21 +610,19 @@ public class ONPRC_EHRController extends SpringActionController
                 if (counter % 1000 == 0)
                 {
                     newBatch = true;
-                    sql.append(") AS updates(dsrowid, caseNo) ");
-                    sql.append("ON c.dsrowid = updates.dsrowid");
+                    sql.append(sqlEnd);
 
                     new SqlExecutor(ti.getSchema()).execute(sql);
 
                     logger.info(counter + " total case numbers added.");
 
-                    sql = new SQLFragment("UPDATE c SET c.caseNo = updates.caseNo FROM studydataset." + _casesProvisionedName + " c JOIN (VALUES ");
+                    sql = new SQLFragment().append(sqlStart);
                 }
             }
 
             if (!newBatch)
             {
-                sql.append(") AS updates(dsrowid, caseNo) ");
-                sql.append("ON c.dsrowid = updates.dsrowid");
+                sql.append(sqlEnd);
                 new SqlExecutor(ti.getSchema()).execute(sql);
             }
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRController.java
@@ -601,7 +601,7 @@ public class ONPRC_EHRController extends SpringActionController
                 counter++;
 
                 // Batch boundary
-                if (counter % 5000 == 0)
+                if (counter % 1000 == 0)
                 {
                     newBatch = true;
                     sql.append(") AS updates(dsrowid, caseNo) ");

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
@@ -16,6 +16,7 @@
 package org.labkey.onprc_ehr;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.query.Queryable;
@@ -90,6 +91,8 @@ public class ONPRC_EHRManager
     @Queryable
     public static final String CAGE_MEDICAL_EXEMPTION_FLAG = "Medical";
 
+    private String _caseSequence = "org.labkey.onprc_ehr.cases";
+
     private ONPRC_EHRManager()
     {
 
@@ -146,6 +149,11 @@ public class ONPRC_EHRManager
         }
 
         return ret;
+    }
+
+    public long getNextCaseNo(Container c)
+    {
+        return DbSequenceManager.get(c, _caseSequence).next();
     }
 }
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRManager.java
@@ -91,7 +91,7 @@ public class ONPRC_EHRManager
     @Queryable
     public static final String CAGE_MEDICAL_EXEMPTION_FLAG = "Medical";
 
-    private String _caseSequence = "org.labkey.onprc_ehr.cases";
+    private static final String CASE_SEQUENCE = "org.labkey.onprc_ehr.cases";
 
     private ONPRC_EHRManager()
     {
@@ -153,7 +153,7 @@ public class ONPRC_EHRManager
 
     public long getNextCaseNo(Container c)
     {
-        return DbSequenceManager.get(c, _caseSequence).next();
+        return DbSequenceManager.get(c, CASE_SEQUENCE).next();
     }
 }
 

--- a/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
@@ -30,6 +30,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.SQLFragment;
@@ -2629,5 +2630,10 @@ public class ONPRC_EHRTriggerHelper
     public void recalculateAllVetAssignmentRecords()
     {
         EHRDemographicsService.get().recalculateForAllIdsInCache(_container, "onprc_ehr", "vet_assignment", true);
+    }
+
+    public long getNextCaseDisplayId()
+    {
+        return ONPRC_EHRManager.get().getNextCaseNo(_container);
     }
 }

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
@@ -73,6 +73,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1715,9 +1716,12 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         SelectRowsCommand select = new SelectRowsCommand("study", "cases");
         select.addFilter(new Filter("Id", SUBJECTS[0], Filter.Operator.EQUAL));
         select.addFilter(new Filter("category", "Behavior", Filter.Operator.EQUAL));
-        select.setColumns(Arrays.asList("Id", "objectid"));
+        select.setColumns(Arrays.asList("Id", "objectid, caseNo"));
         SelectRowsResponse resp = select.execute(getApiHelper().getConnection(), getContainerPath());
         String caseId = (String)resp.getRows().get(0).get("objectid");
+        Integer caseNo = (Integer)resp.getRows().get(0).get("caseNo");
+
+        assertNotNull("Case number is missing.", caseNo);
 
         getApiHelper().deleteAllRecords("study", "clinical_observations", new Filter("Id", SUBJECTS[0], Filter.Operator.EQUAL));
         InsertRowsCommand insertRowsCommand = new InsertRowsCommand("study", "clinical_observations");


### PR DESCRIPTION
#### Rationale
Adding human readable case numbers to cases will add clarity to reporting and data entry.

#### Changes
* Add DBSequencer to manage case ids
* Add trigger for new cases
* Add API to find cases without case numbers and update them with a case number
* Add UI to initiate case number additions
