### PR TITLE
Rename SaveRowsResponse to RowsResponse

### DIFF
--- a/HormoneAssay/test/src/org/labkey/test/tests/external/labModules/HormoneAssayTest.java
+++ b/HormoneAssay/test/src/org/labkey/test/tests/external/labModules/HormoneAssayTest.java
@@ -24,7 +24,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.Locator;
@@ -631,7 +631,7 @@ public class HormoneAssayTest extends AbstractLabModuleAssayTest
                 row.put("code", tests.get(test)[0]);
                 row.put("units", tests.get(test)[1]);
                 insertCmd.addRow(row);
-                SaveRowsResponse saveResp = insertCmd.execute(cn, getProjectName());
+                RowsResponse saveResp = insertCmd.execute(cn, getProjectName());
                 assertEquals("Incorrect row count", 1, saveResp.getRowsAffected().intValue());
             }
         }

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -23,7 +23,7 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.Locator;
@@ -400,7 +400,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
                 }
             });
 
-            SaveRowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
+            RowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
             objectid = (String)saveRowsResponse.getRows().get(0).get("objectid");
         }
 
@@ -450,7 +450,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
                 }
             });
 
-            SaveRowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
+            RowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
             groupId = (Integer)saveRowsResponse.getRows().get(0).get("rowid");
         }
 
@@ -500,7 +500,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
                 }
             });
 
-            SaveRowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
+            RowsResponse saveRowsResponse = insertRowsCommand.execute(getApiHelper().getConnection(), getContainerPath());
             objectid = (String)saveRowsResponse.getRows().get(0).get("objectid");
         }
 

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
@@ -30,7 +30,7 @@ import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.ExecuteSqlCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
@@ -250,7 +250,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         insertRowsCommand1.addRow(getApiHelper().createHashMap(birthFields, new Object[]{offspringId7, birthDate, "Live Birth", null, null, "f", room1, cage1, damId1, null, weight, birthDate, "In Progress"}));
         insertRowsCommand1.addRow(getApiHelper().createHashMap(birthFields, new Object[]{offspringId8, birthDate, "Live Birth", null, null, "f", room1, cage1, damId1, null, weight, birthDate, "Completed"}));
         insertRowsCommand1.setTimeout(0);
-        SaveRowsResponse insertRowsResp = insertRowsCommand1.execute(getApiHelper().getConnection(), getContainerPath());
+        RowsResponse insertRowsResp = insertRowsCommand1.execute(getApiHelper().getConnection(), getContainerPath());
 
         final Map<String, String> lsidMap = new HashMap<>();
         for (Map<String, Object> row : insertRowsResp.getRows())
@@ -757,7 +757,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         String U24_PROJECT = "0492-03";
         InsertRowsCommand projectCommand = new InsertRowsCommand("ehr", "project");
         projectCommand.addRow(Maps.of("project", null, "name", U24_PROJECT, "protocol", DUMMY_PROTOCOL));
-        SaveRowsResponse saveRowsResponse = projectCommand.execute(getApiHelper().getConnection(), getContainerPath());
+        RowsResponse saveRowsResponse = projectCommand.execute(getApiHelper().getConnection(), getContainerPath());
         Integer projectId = (Integer)saveRowsResponse.getRows().get(0).get("project");
 
         // Insert dam project assignment into assignment via API


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-java/pull/83 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/83

#### Changes
- Rename `SaveRowsResponse` to `RowsResponse`
