### PR TITLE
Link crawler test

### DIFF
--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -98,9 +98,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         super._containerHelper.enableModule("ONPRC_BillingPublic");
         super._containerHelper.enableModule("SLA");
         goToEHRFolder();
-        super._containerHelper.enableModule("ONPRC_Billing");
-        super._containerHelper.enableModule("ONPRC_BillingPublic");
-        super._containerHelper.enableModule("SLA");
+        super._containerHelper.enableModules(List.of("ONPRC_Billing", "ONPRC_BillingPublic", "SLA"));
         super.setEHRModuleProperties(
                 new ModulePropertyValue("ONPRC_Billing", "/" + getProjectName(), "BillingContainer", "/" + getContainerPath()),
                 new ModulePropertyValue("ONPRC_Billing", "/" + getProjectName(), "BillingContainer_Public", "/" + getContainerPath()),

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -84,12 +84,6 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
     }
 
     @Override
-    public String getContainerPath()
-    {
-        return getProjectName();
-    }
-
-    @Override
     protected EHRClientAPIHelper getApiHelper()
     {
         return new EHRClientAPIHelper(this, getContainerPath());
@@ -100,6 +94,10 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
     {
         log("Setting EHR Module Properties");
         clickProject(getProjectName());
+        super._containerHelper.enableModule("ONPRC_Billing");
+        super._containerHelper.enableModule("ONPRC_BillingPublic");
+        super._containerHelper.enableModule("SLA");
+        goToEHRFolder();
         super._containerHelper.enableModule("ONPRC_Billing");
         super._containerHelper.enableModule("ONPRC_BillingPublic");
         super._containerHelper.enableModule("SLA");
@@ -134,7 +132,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         log("creating birth records");
 
         //note: these should cascade insert into demographics
-        EHRClientAPIHelper apiHelper = new EHRClientAPIHelper(this, getProjectName());
+        EHRClientAPIHelper apiHelper = new EHRClientAPIHelper(this, getContainerPath());
         String schema = "study";
         String query = "birth";
         String parentageQuery = "parentage";
@@ -185,12 +183,12 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
     protected void doExtraPreStudyImportSetup() throws IOException, CommandException
     {
         //create onprc_billing_public linked schema
-        beginAt(getProjectName());
+        goToEHRFolder();
         SchemaHelper schemaHelper = new SchemaHelper(this);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "onprc_billing_public", "/" + this.getContainerPath(), "onprc_billing_public", null, null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "onprc_billing_public", "/" + getContainerPath(), "onprc_billing_public", null, null, null);
 
         //create Labfee_NoChargeProjects
-        beginAt(getProjectName());
+        goToEHRFolder();
 
         ListDefinition listDef = new IntListDefinition("Labfee_NoChargeProjects", "key");
         listDef.addField(new FieldDefinition("project", FieldDefinition.ColumnType.Integer));
@@ -198,7 +196,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         listDef.addField(new FieldDefinition("dateDisabled", FieldDefinition.ColumnType.DateAndTime));
         listDef.addField(new FieldDefinition("Createdb", FieldDefinition.ColumnType.Integer));
         listDef.addField(new FieldDefinition("Notes", FieldDefinition.ColumnType.String));
-        listDef.getCreateCommand().execute(createDefaultConnection(), getProjectName());
+        listDef.getCreateCommand().execute(createDefaultConnection(), getContainerPath());
 
         ListDefinition listDef2 = new VarListDefinition("GeneticValue");
         listDef2.setKeyName("Id");
@@ -212,12 +210,12 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         listDef2.addField(new FieldDefinition("import", FieldDefinition.ColumnType.String));
         listDef2.addField(new FieldDefinition("value", FieldDefinition.ColumnType.String));
         listDef2.addField(new FieldDefinition("rank", FieldDefinition.ColumnType.Integer));
-        listDef2.getCreateCommand().execute(createDefaultConnection(), getProjectName());
+        listDef2.getCreateCommand().execute(createDefaultConnection(), getContainerPath());
 
         ListDefinition listDef3 = new IntListDefinition("Special_Aliases", "Key");
         listDef3.addField(new FieldDefinition("Category", FieldDefinition.ColumnType.String));
         listDef3.addField(new FieldDefinition("Alias", FieldDefinition.ColumnType.String));
-        listDef3.getCreateCommand().execute(createDefaultConnection(), getProjectName());
+        listDef3.getCreateCommand().execute(createDefaultConnection(), getContainerPath());
 
         ListDefinition listDef4 = new IntListDefinition("Rpt_ChargesProjection", "RowId");
         listDef4.addField(new FieldDefinition("ChargeId", FieldDefinition.ColumnType.Integer));
@@ -240,7 +238,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         listDef4.addField(new FieldDefinition("Aprate8", FieldDefinition.ColumnType.Decimal));
         listDef4.addField(new FieldDefinition("Aprate9", FieldDefinition.ColumnType.Decimal));
         listDef4.addField(new FieldDefinition("PostedDate", FieldDefinition.ColumnType.DateAndTime));
-        listDef4.getCreateCommand().execute(createDefaultConnection(), getProjectName());
+        listDef4.getCreateCommand().execute(createDefaultConnection(), getContainerPath());
 
         // Mock up a table in the MHC_Data schema instead of needing to mock up all of its dependencies too
         ListDefinition listDef5 = new IntListDefinition("MHC_Data_Unified", "RowId");
@@ -255,17 +253,17 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
         listDef5.addField(new FieldDefinition("datatype", FieldDefinition.ColumnType.String));
         listDef5.addField(new FieldDefinition("result", FieldDefinition.ColumnType.String));
         listDef5.addField(new FieldDefinition("type", FieldDefinition.ColumnType.String));
-        listDef5.getCreateCommand().execute(createDefaultConnection(), getProjectName());
+        listDef5.getCreateCommand().execute(createDefaultConnection(), getContainerPath());
 
-        schemaHelper.createLinkedSchema(this.getProjectName(), "dbo", "/" + this.getContainerPath(), null, "lists", null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "MHC_Data", "/" + this.getContainerPath(), null, "lists", null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "ehrSLA", "/" + this.getContainerPath(), "ehrSLA", "sla", null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "financepublic", "/" + this.getContainerPath(), "financepublic", "onprc_billing", null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "publicehr", "/" + this.getContainerPath(), null, "ehr", null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "onprc_ehrSLA", "/" + this.getContainerPath(), null, "onprc_ehr", null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "pf_onprcehrPublic", "/" + this.getContainerPath(), "pf_onprcehrPublic", null, null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "pf_publicEHR", "/" + this.getContainerPath(), "pf_publicEHR", null, null, null);
-        schemaHelper.createLinkedSchema(this.getProjectName(), "pf_publicFinance", "/" + this.getContainerPath(), "pf_publicFinance", null, null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "dbo", "/" + getContainerPath(), null, "lists", null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "MHC_Data", "/" + getContainerPath(), null, "lists", null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "ehrSLA", "/" + getContainerPath(), "ehrSLA", "sla", null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "financepublic", "/" + getContainerPath(), "financepublic", "onprc_billing", null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "publicehr", "/" + getContainerPath(), null, "ehr", null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "onprc_ehrSLA", "/" + getContainerPath(), null, "onprc_ehr", null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "pf_onprcehrPublic", "/" + getContainerPath(), "pf_onprcehrPublic", null, null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "pf_publicEHR", "/" + getContainerPath(), "pf_publicEHR", null, null, null);
+        schemaHelper.createLinkedSchema(getContainerPath(), "pf_publicFinance", "/" + getContainerPath(), "pf_publicFinance", null, null, null);
     }
 
     @Override

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractONPRC_EHRTest.java
@@ -55,4 +55,10 @@ public abstract class AbstractONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
 
     @Override
     public void customActionsTest(){}
+
+    @Override
+    public void testCrawlEhrLinks()
+    {
+        // This is being done in ONPRC_EHRTest, don't need to do it here as well.
+    }
 }

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
@@ -101,6 +101,12 @@ public class ONPRC_BillingTest extends AbstractONPRC_EHRTest
         _portalHelper.moveWebPart("Finance", PortalHelper.Direction.UP);
     }
 
+    @Override
+    public void testCrawlEhrLinks()
+    {
+        // This is being done in ONPRC_EHRTest, don't need to do it here as well.
+    }
+
     @Test
     public void testNotifications()
     {

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_BillingTest.java
@@ -100,13 +100,7 @@ public class ONPRC_BillingTest extends AbstractONPRC_EHRTest
         _portalHelper.addWebPart("ONPRC Finance");
         _portalHelper.moveWebPart("Finance", PortalHelper.Direction.UP);
     }
-
-    @Override
-    public void testCrawlEhrLinks()
-    {
-        // This is being done in ONPRC_EHRTest, don't need to do it here as well.
-    }
-
+    
     @Test
     public void testNotifications()
     {

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest.java
@@ -81,7 +81,7 @@ import static org.junit.Assert.fail;
 public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
 {
     protected String PROJECT_NAME = "ONPRC_EHR_TestProject";
-    private final String ANIMAL_HISTORY_URL = "/" + getProjectName() + "/ehr-animalHistory.view";
+    private final String ANIMAL_HISTORY_URL = "/" + getContainerPath() + "/ehr-animalHistory.view";
 
     @Override
     protected String getProjectName()
@@ -160,7 +160,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     {
         final String investLastName = "Tester";
 
-        goToProjectHome();
+        goToEHRFolder();
 
         String[][] CONDITION_FLAGS = new String[][]{
                 {"Nonrestricted", "201"},
@@ -345,7 +345,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     @Test
     public void testAnimalGroupsApi() throws Exception
     {
-        goToProjectHome();
+        goToEHRFolder();
 
         int group1 = getOrCreateGroup("Group1");
         int group2 = getOrCreateGroup("Group2");
@@ -364,7 +364,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     @Test
     public void testProjectProtocolApi() throws Exception
     {
-        goToProjectHome();
+        goToEHRFolder();
 
         //auto-assignment of IDs
         String protocolTitle = generateGUID();
@@ -399,7 +399,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     @Test
     public void testDrugApi()
     {
-        goToProjectHome();
+        goToEHRFolder();
 
         getApiHelper().testValidationMessage(DATA_ADMIN.getEmail(), "study", "drug", new String[]{"Id", "date", "code", "outcome", "remark", "amount", "amount_units", "volume", "vol_units", "QCStateLabel", "objectid", "_recordId"}, new Object[][]{
                 {MORE_ANIMAL_IDS[0], new Date(), "code", "Abnormal", null, 1.0, "mg", 2.0, "mL", EHRQCState.COMPLETED.label, generateGUID(), "recordID"}
@@ -470,7 +470,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     @Test
     public void testArrivalApi() throws Exception
     {
-        goToProjectHome();
+        goToEHRFolder();
 
         final String arrivalId1 = "Arrival1";
         final String arrivalId2 = "Arrival2";
@@ -578,11 +578,11 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         }
 
         //colony overview
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.tagContainingText("a", "Colony Overview"));
 
         //NOTE: depending on the test order and whether demographics records were created, so we test this
-        EHRClientAPIHelper apiHelper = new EHRClientAPIHelper(this, getProjectName());
+        EHRClientAPIHelper apiHelper = new EHRClientAPIHelper(this, getContainerPath());
         boolean hasDemographics = apiHelper.getRowCount("study", "demographics") > 0;
         boolean hasCases = apiHelper.getRowCount("study", "cases") > 0;
         int aggregatePanelCount = 0;
@@ -629,7 +629,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
 
         //bulk history export
         log("testing bulk history export");
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.tagContainingText("a", "Bulk History Export"));
         waitForElement(Locator.tagContainingText("label", "Enter Animal Id(s)"));
         Ext4FieldRef.getForLabel(this, "Enter Animal Id(s)").setValue("12345;23432\nABCDE");
@@ -643,7 +643,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         assertElementNotPresent(Locator.tagContainingText("label", "Projects").notHidden()); //check redaction
 
         //compare lists of animals
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.tagContainingText("a", "Compare Lists of Animals"));
         waitForElement(Locator.id("unique"));
         setFormElement(Locator.id("unique"), "1,2,1\n3,3;4");
@@ -673,7 +673,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         ensureGroupMember(groupId, MORE_ANIMAL_IDS[0]);
         ensureGroupMember(groupId, MORE_ANIMAL_IDS[1]);
 
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.tagContainingText("a", "Animal Groups"));
         waitForElement(Locator.tagContainingText("span", "Active Groups"));
         DataRegionTable dr = new DataRegionTable("query", this);
@@ -682,7 +682,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         Assert.assertEquals(2, membersTable.getDataRowCount());
 
         //more reports
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.tagContainingText("a", "More Reports"));
         waitForElement(Locator.tagContainingText("a", "View Summary of Clinical Tasks"));
     }
@@ -691,7 +691,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     public void testPrintableReports()
     {
         // NOTE: these primarily run SSRS, so we will just set up the UI and test whether the URL matches expectations
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.tagContainingText("a", "Printable Reports"));
         waitForElement(Ext4Helper.Locators.ext4Button("Print Version"));
 
@@ -716,7 +716,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         closeExtraWindows();
 
         // Now try the CITES Report
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.tagContainingText("a", "More Reports"));
         waitAndClickAndWait(Locator.tagContainingText("a", "Cites Report"));
         waitForElement(Locator.textarea("animalField"));
@@ -748,7 +748,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     @Test
     public void testPedigreeReport()
     {
-        goToProjectHome();
+        goToEHRFolder();
         beginAtAnimalHistoryTab();
 
         String id = ID_PREFIX + 10;
@@ -1246,7 +1246,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     @Test
     public void testGeneticsPipeline()
     {
-        goToProjectHome();
+        goToEHRFolder();
 
         //retain pipeline log for debugging
         getArtifactCollector().addArtifactLocation(new File(TestFileUtils.getLabKeyRoot(), getModulePath() + GENETICS_PIPELINE_LOG_PATH),
@@ -1269,7 +1269,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
         Test coverage for : https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=41231
         */
 
-        goToProjectHome();
+        goToEHRFolder();
         beginAtAnimalHistoryTab();
         AnimalHistoryPage<?> animalHistoryPage = new AnimalHistoryPage<>(getDriver());
         animalHistoryPage.searchSingleAnimal("99995,99996,99997,99998,99999,999910");
@@ -1315,7 +1315,7 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     {
         setupNotificationService();
 
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locators.bodyPanel().append(Locator.tagContainingText("a", "EHR Admin Page")));
         waitAndClickAndWait(Locator.tagContainingText("a", "Notification Admin"));
 
@@ -1758,6 +1758,8 @@ public class ONPRC_EHRTest extends AbstractGenericONPRC_EHRTest
     @Test
     public void testBehaviorRounds() throws Exception
     {
+        goToEHRFolder();
+
         _helper.goToTaskForm("BSU Rounds");
 
         //create a previous observation for the active case

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
@@ -82,7 +82,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
     private final String PROJECT_NAME = "ONPRC_EHR_TestProject2";
     private final String ANIMAL_HISTORY_URL = "/ehr/" + getProjectName() + "/animalHistory.view?";
     public AbstractContainerHelper _containerHelper = new APIContainerHelper(this);
-    public DataIntegrationHelper _etlHelper = new DataIntegrationHelper(PROJECT_NAME);
+    public DataIntegrationHelper _etlHelper = new DataIntegrationHelper(getContainerPath());
     protected DateTimeFormatter _dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @BeforeClass

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
@@ -122,6 +122,12 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         return true;
     }
 
+    @Override
+    public void testCrawlEhrLinks()
+    {
+        // This is being done in ONPRC_EHRTest, don't need to do it here as well.
+    }
+
     @Test
     public void testBirthStatusApi() throws Exception
     {

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
@@ -125,7 +125,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
     @Test
     public void testBirthStatusApi() throws Exception
     {
-        goToProjectHome();
+        goToEHRFolder();
 
         //first create record for dam, along w/ animal group and SPF status.  we expect this to automatically create a demographics record w/ the right status
         final String damId1 = "Dam1";
@@ -724,7 +724,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         Date damBirth = prepareDate(DateUtils.truncate(new Date(), Calendar.DATE), -720, 0);
 
         // Navigate to the start of the project
-        goToProjectHome();
+        goToEHRFolder();
 
         // Insert dam into birth via API
         log("Creating Dam");
@@ -860,7 +860,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         });
         getApiHelper().doSaveRows(PasswordUtil.getUsername(), insertCommand, getExtraContext());
 
-        goToProjectHome();
+        goToEHRFolder();
         waitAndClickAndWait(Locator.linkWithText("Animal History"));
 
         String query = "textfield[itemId=subjArea]";
@@ -1267,7 +1267,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         String animalId = "12345";
 
         log("Creating the Treatment order request");
-        goToProjectHome();
+        goToEHRFolder();
         clickAndWait(Locator.linkWithText("Enter Data / Task Review"));
         waitAndClickAndWait(Locator.linkWithText("Medications/Diet"));
 
@@ -1302,7 +1302,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         LocalDateTime now = LocalDateTime.now();
         String animalId = "12345";
 
-        goToProjectHome();
+        goToEHRFolder();
 
         log("Inserting the charge unit necessary for blood draw request");
         InsertRowsCommand chargeUnitCommand = new InsertRowsCommand("onprc_billing", "chargeUnits");

--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
@@ -122,12 +122,6 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         return true;
     }
 
-    @Override
-    public void testCrawlEhrLinks()
-    {
-        // This is being done in ONPRC_EHRTest, don't need to do it here as well.
-    }
-
     @Test
     public void testBirthStatusApi() throws Exception
     {


### PR DESCRIPTION
#### Rationale
Link crawler test validates links in the EHR folder. ONPRC tests have not used this folder in the past. This converts to using the EHR folder for tests, which more closely matches the production server.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/997

#### Changes
* Remove container path override
* Update setup to configure EHR folder
* Update tests to start in the EHR folder
