### PR TITLE
Support BIGINT Primary Keys

### DIFF
--- a/GeneticsCore/src/org/labkey/GeneticsCore/GeneticsCoreExpListener.java
+++ b/GeneticsCore/src/org/labkey/GeneticsCore/GeneticsCoreExpListener.java
@@ -63,6 +63,7 @@ public class GeneticsCoreExpListener implements ExperimentListener
         {
             return;
         }
+
         TableSelector ts = new TableSelector(data, PageFlowUtil.set("RowId", "SubjectId"), new SimpleFilter(FieldKey.fromString("Run"), run.getRowId()), null);
         List<Map<String, Object>> resultRows = new ArrayList<>();
         ts.forEachResults(rs -> {

--- a/HormoneAssay/src/org/labkey/hormoneassay/assay/RocheE411ImportMethod.java
+++ b/HormoneAssay/src/org/labkey/hormoneassay/assay/RocheE411ImportMethod.java
@@ -4,6 +4,7 @@ import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -157,7 +158,7 @@ public class RocheE411ImportMethod extends DefaultImportMethod
         {
             ParserErrors errors = context.getErrors();
 
-            Map<Integer, Integer> testColumnMap = new HashMap<>();
+            Map<Integer, Integer> testColumnMap = new IntHashMap<>();
 
             Map<String, Integer> headerMap = new HashMap<>();
             headerMap.put("well", 3);

--- a/onprc_billing/src/org/labkey/onprc_billing/query/BillingTriggerHelper.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/query/BillingTriggerHelper.java
@@ -3,6 +3,7 @@ package org.labkey.onprc_billing.query;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -138,7 +139,7 @@ public class BillingTriggerHelper
         return false; //unknown charge, assume false
     }
 
-    private final Map<Integer, Map<String, Object>> _cachedCharges = new HashMap<>();
+    private final Map<Integer, Map<String, Object>> _cachedCharges = new IntHashMap<>();
 
     private Map<String, Object> getCharge(Integer chargeId)
     {

--- a/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -109,17 +110,17 @@ public class ONPRC_EHRTriggerHelper
     private final Container _container;
     private final User _user ;
     private final Map<String, Map<String, Object>> _cachedRooms = new HashMap<>();
-    private final Map<Integer, Pair<String, String>> _cachedProtocols = new HashMap<>();
+    private final Map<Integer, Pair<String, String>> _cachedProtocols = new IntHashMap<>();
     private final Map<String, Map<String, Set<String>>> _cachedHousing = new HashMap<>();
-    private final Map<Integer, String> _cachedProcedureCategories = new HashMap<>();
+    private final Map<Integer, String> _cachedProcedureCategories = new IntHashMap<>();
 
     //NOTE: we probably do not want to cache this outside this transaction, unless we can keep it accurate
     private final Map<String, List<CageRecord>> _cachedCages = new HashMap<>();
-    private final Map<Integer, Boolean> _cachedFrequencies = new HashMap<>();
-    private final Map<Integer, List<Integer>> _cachedFrequencyTimes = new HashMap<>();
+    private final Map<Integer, Boolean> _cachedFrequencies = new IntHashMap<>();
+    private final Map<Integer, List<Integer>> _cachedFrequencyTimes = new IntHashMap<>();
     private final Map<String, Integer> _cachedConditionCodes = new HashMap<>();
     private final Map<String, Integer> _cachedConditionCodeMeanings = new HashMap<>();
-    private final Map<Integer, DividerRecord> _cachedDividerRecords = new HashMap<>();
+    private final Map<Integer, DividerRecord> _cachedDividerRecords = new IntHashMap<>();
     private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd kk:mm");
 
     private Map<String, Boolean> _cachedBirthConditions = null;


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->
