### PR TITLE
Include trigger name in verifyNotUsed() signature update

### DIFF
--- a/ONPRC_EHR_ComplianceDB/resources/queries/EHR_ComplianceDB/requirements.js
+++ b/ONPRC_EHR_ComplianceDB/resources/queries/EHR_ComplianceDB/requirements.js
@@ -63,7 +63,7 @@ function beforeDelete(row, errors){
         query = queries[j];
         for (var i=0;i<fields.length;i++){
             fieldName = fields[i];
-            if (helper.verifyNotUsed('ehr_compliancedb', query, 'requirementname', row[fieldName])){
+            if (helper.verifyNotUsed('ehr_compliancedb', query, 'requirementname', row[fieldName], 'requirements')){
                 addError(errors, fieldName, 'Cannot delete row with value: ' + row[fieldName] + ' because it is referenced by the table ' + query);
             }
         }

--- a/onprc_billing/resources/queries/onprc_billing/chargeableItems.js
+++ b/onprc_billing/resources/queries/onprc_billing/chargeableItems.js
@@ -11,11 +11,11 @@ var helper = org.labkey.ldk.query.LookupValidationHelper.create(LABKEY.Security.
 var ehrHelper = org.labkey.ehr.utils.TriggerScriptHelper.create(LABKEY.Security.currentUser.id, LABKEY.Security.currentContainer.id);
 
 function beforeDelete(row, errors){
-    if (helper.verifyNotUsed('onprc_billing', 'invoicedItems', 'chargeid', row['rowid'])){
+    if (helper.verifyNotUsed('onprc_billing', 'invoicedItems', 'chargeid', row['rowid'], 'chargeableItems')){
         addError(errors, 'name', 'Cannot delete row with ID: ' + row['rowid'] + ' because it is referenced by the table invoicedItems.  You should inactivate this item instead.');
     }
 
-    if (helper.verifyNotUsed('onprc_billing', 'miscCharges', 'chargeid', row['rowid'], ehrHelper.getEHRStudyContainerPath())){
+    if (helper.verifyNotUsed('onprc_billing', 'miscCharges', 'chargeid', row['rowid'], ehrHelper.getEHRStudyContainerPath(), 'chargeableItems')){
         addError(errors, 'name', 'Cannot delete row with ID: ' + row['rowid'] + ' because it is referenced by the table miscCharges.  You should inactivate this item instead.');
     }
 }


### PR DESCRIPTION
#### Rationale
The signature of LookupValidationHelper.verifyNotUsed() now includes the script name (for a better error message). This PR updates the callers accordingly.

#### Related Pull Requests
* https://github.com/LabKey/LabDevKitModules/pull/259

#### Changes
* Include trigger name in verifyNotUsed() call
