### PR TITLE
Add Master Problems to Open Cases for Vet Assignment

### DIFF
--- a/onprc_ehr/resources/queries/study/demographicsAssignedVet.query.xml
+++ b/onprc_ehr/resources/queries/study/demographicsAssignedVet.query.xml
@@ -4,8 +4,8 @@
             <table tableName="demographicsAssignedVet" tableDbType="NOT_IN_DB">
                 <tableTitle>Assigned Vets</tableTitle>
                 <columns>
-                    <column columnName="matchedRule">
-                        <isHidden>true</isHidden>
+                    <column columnName="AssignmentType">
+                        <url replaceMissing="blankValue">executeQuery.view?schemaName=study&amp;query.queryName=VetAssignment_Filter&amp;query.Id~contains=${Id}</url>
                     </column>
                 </columns>
             </table>

--- a/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
+++ b/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
@@ -1,17 +1,9 @@
 /*
 study.demographicsAssignedVet
 
-Returns one or more assigned vets per animal ID
-  * When there is an open case, it returns one record for each vet having an open
-    case for that animal
-  * When there is not an open case, it returns one record for the lowest-numbered
-    matched rule
-  * VAF2 determines the lowest matched rule for each animal. Doing an inner join
-    with VAF1 results in only those records matching the lowest matched rule per
-    animal. The select distinct limits it to a single record.
-
-Per Lindsay's request, this user-defined query includes all the fields that the
-Vet Assignment Raw Data file does.
+* Returns one or more assigned vets per animal ID
+* Note to future self: don't be tempted to add more fields to this view. It will likely
+  result in additional rows per animal as they won't be distinct.
 
  */
 
@@ -31,17 +23,9 @@ SELECT DISTINCT
     VAF1.Id,
     VAF1.AssignedVet,
     VAF1.AssignmentType,
---    VAF1.CaseVet,
---    VAF1.CaseDate,
---    VAF1.Project,
---    VAF1.ProjectType,
---    VAF1.Protocol,
---    VAF1.ProtocolPI,
     VAF1.Room,
     VAF1.Area,
     VAF1.Species
---    VAF1.Calculated_status,
---    VAF1.MatchedRule
 
 FROM
     vetAssignment_Filter AS VAF1

--- a/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
+++ b/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
@@ -8,14 +8,11 @@ Returns one or more assigned vets per animal ID
     matched rule
   * VAF2 determines the lowest matched rule for each animal. Doing an inner join
     with VAF1 results in only those records matching the lowest matched rule per
-    animal. The select distinct limits it to a single recorVAF1.
+    animal. The select distinct limits it to a single record.
 
-Future enhancements
-  * Add ProjectType to select statement and hide in XML
-  * Add Protocol_PI to study.vet_assignmentFilter and to onprc_ehr.vet_assignment
-  * Add species to onprc_ehr.vet_assignment
-  * Add validation to onprc_ehr.vet_assignment to prevent creating a rule that has
-  *   no match in the filter
+Per Lindsay's request, this user-defined query includes all the fields that the
+Vet Assignment Raw Data file does.
+
  */
 
 -- Step 1: Find the minimum matchedRule for each ID
@@ -24,7 +21,7 @@ WITH MinMatchedRules AS (
         VAF2.Id,
         MIN(VAF2.matchedRule) AS MinRule
     FROM
-        vetAssignment_filter AS VAF2
+        vetAssignment_Filter AS VAF2
     GROUP BY
         VAF2.Id
 )
@@ -37,7 +34,7 @@ SELECT DISTINCT
     VAF1.CaseVet,
     VAF1.CaseDate,
     VAF1.Project,
-    VAF1.AssignmentType AS ProjectType,
+    VAF1.ProjectType,
     VAF1.Protocol,
     VAF1.ProtocolPI,
     VAF1.Room,
@@ -47,8 +44,8 @@ SELECT DISTINCT
     VAF1.MatchedRule
 
 FROM
-    vetAssignment_filter AS VAF1
-INNER JOIN
+    vetAssignment_Filter AS VAF1
+        INNER JOIN
     MinMatchedRules AS MMR
     ON VAF1.Id = MMR.Id
-    AND VAF1.matchedRule = MMR.MinRule
+        AND VAF1.matchedRule = MMR.MinRule

--- a/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
+++ b/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
@@ -31,17 +31,17 @@ SELECT DISTINCT
     VAF1.Id,
     VAF1.AssignedVet,
     VAF1.AssignmentType,
-    VAF1.CaseVet,
-    VAF1.CaseDate,
-    VAF1.Project,
-    VAF1.ProjectType,
-    VAF1.Protocol,
-    VAF1.ProtocolPI,
+--    VAF1.CaseVet,
+--    VAF1.CaseDate,
+--    VAF1.Project,
+--    VAF1.ProjectType,
+--    VAF1.Protocol,
+--    VAF1.ProtocolPI,
     VAF1.Room,
     VAF1.Area,
-    VAF1.Species,
-    VAF1.Calculated_status,
-    VAF1.MatchedRule
+    VAF1.Species
+--    VAF1.Calculated_status,
+--    VAF1.MatchedRule
 
 FROM
     vetAssignment_Filter AS VAF1

--- a/onprc_ehr/resources/queries/study/vetAssignment_demographics.sql
+++ b/onprc_ehr/resources/queries/study/vetAssignment_demographics.sql
@@ -11,28 +11,33 @@ Notes:
     might not have records for an animal ID. Left joins are used for all
 	other joins to be resilient against missing data.
  */
-SELECT demographics.id,
-       CMUcases.assignedVet.displayName AS caseVet,
-       CMUcases.date AS caseDate,
-       housing.room,
-       housing.room.area,
-       assignedProject.project AS project,
-       assignedProject.Protocol AS protocol,
-       assignedProject.PI AS protocolPI,
-       assignedProject.projectType AS assignmentType,
-       demographics.calculated_status,
-       demographics.gender,
-       demographics.species,
-       demographics.history
-FROM Site.{ substitutePath moduleProperty('EHR', 'EHRStudyContainer') }.study.animal AS nhp
-LEFT JOIN Site.{ substitutePath moduleProperty('EHR', 'EHRStudyContainer') }.study.ClinicalCases_Open AS CMUcases
-    ON CMUcases.id = nhp.id
-LEFT JOIN Site.{ substitutePath moduleProperty('EHR', 'EHRStudyContainer') }.study.housing AS housing
-    ON housing.id = nhp.id
-LEFT JOIN Site.{ substitutePath moduleProperty('EHR', 'EHRStudyContainer') }.study.demographics AS demographics
-    ON demographics.id = nhp.id
-LEFT JOIN Site.{ substitutePath moduleProperty('EHR', 'EHRStudyContainer') }.study.vetAssignment_projects AS assignedProject
-    ON assignedProject.id = nhp.id
-WHERE demographics.Calculated_Status = 'Alive'
-  AND nhp.id NOT LIKE '[A-Z]%'
-  AND housing.enddate IS NULL
+
+WITH CasesData AS (
+    SELECT Id,
+           Open_CMU_Cases.AssignedVet.DisplayName AS CaseVet,
+           Open_CMU_Cases.Date AS CaseDate,
+           GROUP_CONCAT(ProblemCategories, ';') AS ActiveMasterProblems
+    FROM Study.ClinicalCases_Open AS Open_CMU_Cases
+    GROUP BY Open_CMU_Cases.AssignedVet.DisplayName, Id, Open_CMU_Cases.Date
+)
+SELECT Demographics.Id,
+       CasesData.CaseVet,
+       CasesData.CaseDate,
+       CasesData.ActiveMasterProblems,
+       Housing.Room,
+       Housing.Room.Area,
+       AssignedProject.Project AS Project,
+       AssignedProject.Protocol AS Protocol,
+       AssignedProject.PI AS ProtocolPI,
+       AssignedProject.ProjectType AS AssignmentType,
+       Demographics.Calculated_Status,
+       Demographics.Gender,
+       Demographics.Species,
+       Demographics.History
+FROM Study.Demographics AS Demographics
+         LEFT JOIN CasesData ON Demographics.Id = CasesData.Id
+         LEFT JOIN Study.Housing AS Housing ON Demographics.Id = Housing.Id
+         LEFT JOIN Study.VetAssignment_projects AS AssignedProject ON Demographics.Id = AssignedProject.Id
+WHERE Demographics.Calculated_Status = 'Alive'
+  AND Demographics.Id NOT LIKE '[A-Z]%'
+  AND Housing.Enddate IS NULL

--- a/onprc_ehr/resources/queries/study/vetAssignment_demographics.sql
+++ b/onprc_ehr/resources/queries/study/vetAssignment_demographics.sql
@@ -1,43 +1,39 @@
 /*
 study.vetAssignment_demographics
 
-Replaces: study.vetAssignmentDemographics
-
 Returns at least one record for all living NHPs at the center.
 Notes:
   * Multiple open cases and multiple assignments for a single animal
     result in open cases * assignments for that animal
-  * Left joins are needed for CMUcases and assignedProject as those tables
-    might not have records for an animal ID. Left joins are used for all
-	other joins to be resilient against missing data.
  */
 
 WITH CasesData AS (
     SELECT Id,
-           Open_CMU_Cases.AssignedVet.DisplayName AS CaseVet,
-           Open_CMU_Cases.Date AS CaseDate,
-           GROUP_CONCAT(ProblemCategories, ';') AS ActiveMasterProblems
+        Open_CMU_Cases.AssignedVet.DisplayName AS CaseVet,
+        Open_CMU_Cases.Date AS CaseDate,
+        GROUP_CONCAT(ProblemCategories, ';') AS ActiveMasterProblems
     FROM Study.ClinicalCases_Open AS Open_CMU_Cases
     GROUP BY Open_CMU_Cases.AssignedVet.DisplayName, Id, Open_CMU_Cases.Date
 )
-SELECT Demographics.Id,
-       CasesData.CaseVet,
-       CasesData.CaseDate,
-       CasesData.ActiveMasterProblems,
-       Housing.Room,
-       Housing.Room.Area,
-       AssignedProject.Project AS Project,
-       AssignedProject.Protocol AS Protocol,
-       AssignedProject.PI AS ProtocolPI,
-       AssignedProject.ProjectType AS AssignmentType,
-       Demographics.Calculated_Status,
-       Demographics.Gender,
-       Demographics.Species,
-       Demographics.History
+SELECT
+    Demographics.Id,
+    CasesData.CaseVet,
+    CasesData.CaseDate,
+    CasesData.ActiveMasterProblems,
+    Housing.Room,
+    Housing.Room.Area,
+    AssignedProject.Project AS Project,
+    AssignedProject.Protocol AS Protocol,
+    AssignedProject.PI AS ProtocolPI,
+    AssignedProject.ProjectType AS AssignmentType,
+    Demographics.Calculated_Status,
+    Demographics.Gender,
+    Demographics.Species,
+    Demographics.History
 FROM Study.Demographics AS Demographics
-         LEFT JOIN CasesData ON Demographics.Id = CasesData.Id
-         LEFT JOIN Study.Housing AS Housing ON Demographics.Id = Housing.Id
-         LEFT JOIN Study.VetAssignment_projects AS AssignedProject ON Demographics.Id = AssignedProject.Id
+LEFT JOIN CasesData ON Demographics.Id = CasesData.Id
+LEFT JOIN Study.Housing AS Housing ON Demographics.Id = Housing.Id
+LEFT JOIN Study.VetAssignment_projects AS AssignedProject ON Demographics.Id = AssignedProject.Id
 WHERE Demographics.Calculated_Status = 'Alive'
-  AND Demographics.Id NOT LIKE '[A-Z]%'
-  AND Housing.Enddate IS NULL
+    AND Demographics.Id NOT LIKE '[A-Z]%'
+    AND Housing.Enddate IS NULL

--- a/onprc_ehr/resources/queries/study/vetassignment_filter.sql
+++ b/onprc_ehr/resources/queries/study/vetassignment_filter.sql
@@ -21,7 +21,7 @@ Notes:
 SELECT *
 FROM (
          SELECT d.Id,
-              CASE
+                CASE
                     WHEN d.CaseVet IS NOT NULL  THEN d.CaseVet
                     WHEN R01.UserID IS NOT NULL THEN R01.UserID.DisplayName
                     WHEN R02.UserID IS NOT NULL THEN R02.UserID.DisplayName
@@ -46,9 +46,9 @@ FROM (
                     WHEN R21.UserID IS NOT NULL THEN R21.UserID.DisplayName
                     WHEN R22.UserID IS NOT NULL THEN R22.UserID.DisplayName
                     ELSE 'Unassigned'
-              END AS AssignedVet,
-              CASE
-                    WHEN d.CaseVet IS NOT NULL 	THEN 'Open Case'
+                    END AS AssignedVet,
+                CASE
+                    WHEN d.CaseVet IS NOT NULL 	THEN ('Open Case' || ' | ' || d.ActiveMasterProblems)
                     WHEN R01.UserID IS NOT NULL THEN 'Room Priority'
                     WHEN R02.UserID IS NOT NULL THEN 'Area Priority'
                     WHEN R03.UserID IS NOT NULL THEN 'Project Room Research Priority'
@@ -72,18 +72,18 @@ FROM (
                     WHEN R21.UserID IS NOT NULL THEN 'Room'
                     WHEN R22.UserID IS NOT NULL THEN 'Area'
                     ELSE 'No Matching Rule'
-              END AS AssignmentType,
-              d.CaseVet,
-              d.CaseDate,
-              d.Project,
-              d.AssignmentType AS ProjectType,
-              d.Protocol,
-              d.ProtocolPI,
-              d.Room,
-              d.Area,
-              d.Calculated_status,
-              d.Species,
-              CASE
+                    END AS AssignmentType,
+                d.CaseVet,
+                d.CaseDate,
+                d.Project,
+                d.AssignmentType AS ProjectType,
+                d.Protocol,
+                d.ProtocolPI,
+                d.Room,
+                d.Area,
+                d.Calculated_status,
+                d.Species,
+                CASE
                     WHEN d.CaseVet IS NOT NULL  THEN 0
                     WHEN R01.UserID IS NOT NULL THEN 1
                     WHEN R02.UserID IS NOT NULL THEN 2
@@ -108,7 +108,7 @@ FROM (
                     WHEN R21.UserID IS NOT NULL THEN 21
                     WHEN R22.UserID IS NOT NULL THEN 22
                     ELSE 99
-             END AS MatchedRule
+                    END AS MatchedRule
          FROM study.vetAssignment_demographics AS d
 
 /* R01 Room Priority                  */ LEFT JOIN onprc_ehr.vet_assignment R01 ON (R01.Room = d.Room AND R01.Area IS NULL AND R01.Project IS NULL AND R01.Protocol IS NULL AND R01.Priority = true)

--- a/onprc_ehr/resources/queries/study/vetassignment_filter.sql
+++ b/onprc_ehr/resources/queries/study/vetassignment_filter.sql
@@ -48,7 +48,7 @@ FROM (
                     ELSE 'Unassigned'
                     END AS AssignedVet,
                 CASE
-                    WHEN d.CaseVet IS NOT NULL 	THEN ('Open Case' || ' | ' || d.ActiveMasterProblems)
+                    WHEN d.CaseVet IS NOT NULL 	THEN 'Open Case'
                     WHEN R01.UserID IS NOT NULL THEN 'Room Priority'
                     WHEN R02.UserID IS NOT NULL THEN 'Area Priority'
                     WHEN R03.UserID IS NOT NULL THEN 'Project Room Research Priority'
@@ -72,7 +72,8 @@ FROM (
                     WHEN R21.UserID IS NOT NULL THEN 'Room'
                     WHEN R22.UserID IS NOT NULL THEN 'Area'
                     ELSE 'No Matching Rule'
-                    END AS AssignmentType,
+                END AS AssignmentType,
+                d.ActiveMasterProblems,
                 d.CaseVet,
                 d.CaseDate,
                 d.Project,


### PR DESCRIPTION
#### Rationale
* The Vets assigned to living animals shows multiple rows per animal even in cases when it shouldn't. Also, when an animal has an open case, the vet assigned to that case is the assigned vet. When an animal has multiple open cases, it can be challenging to distinguish between them. 

#### Related Pull Requests


#### Changes
* Remove "extra" fields from the Vet assigned to living animals to minimize multiple rows per animal.
* Include master problems in the raw data view.
* Link the raw data view filtered by animal from the vets assigned to living animals grid.
