### PR TITLE
Fix treatment order updates

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
@@ -368,6 +368,7 @@ public class ONPRC_EHRTriggerHelper
         Map<String, Object> toCreate = new CaseInsensitiveHashMap<>();
         toCreate.putAll(oldRow);
         toCreate.remove("lsid");
+        toCreate.remove("ParticipantSequenceNum");
 
         String originalObjectId = (String) toCreate.get("objectid");
         assert originalObjectId != null;
@@ -385,12 +386,17 @@ public class ONPRC_EHRTriggerHelper
         List<Map<String, Object>> createdRows = treatmentOrders.getUpdateService().insertRows(getUser(), getContainer(), Arrays.asList(toCreate), errors, null, getExtraContext());
 
         //also update records in drugs table
-        if (!createdRows.isEmpty())
+        if (createdRows != null && !createdRows.isEmpty())
         {
             TableInfo drugAdministration = getRealTable(getTableInfo("study", "Drug Administration"));
             SQLFragment sql = new SQLFragment("UPDATE " + drugAdministration.getSelectName() + " SET treatmentid = ? WHERE treatmentid = ?", newObjectId, originalObjectId);
             SqlExecutor se = new SqlExecutor(drugAdministration.getSchema().getScope());
             se.execute(sql);
+        }
+
+        if (errors.hasErrors())
+        {
+            throw errors;
         }
 
         return now;


### PR DESCRIPTION
#### Rationale
Updating treatment orders is failing on duplicate ParticipantSequenceNum. We shouldn't be passing that in anyway. Also need better error handling.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7076

#### Changes
* Remove ParticipantSequenceNum
* Check for null return and errors
