### PR TITLE
Fix ABV process notification

### DIFF
--- a/onprc_ehr/resources/queries/onprc_ehr/ValidateAvailableBloodProcess.sql
+++ b/onprc_ehr/resources/queries/onprc_ehr/ValidateAvailableBloodProcess.sql
@@ -4,7 +4,6 @@
  */
 
 SELECT DISTINCT
-    MAX(a.DateCreated) AS latestMathematicaABV_data,
-    NOW() AS currentTime
+    MAX(a.DateCreated) AS latestMathematicaABV_data
 FROM AvailableBloodVolume a
 WHERE DateCreated < TIMESTAMPADD('SQL_TSI_MINUTE', -55, NOW())

--- a/onprc_ehr/resources/queries/onprc_ehr/ValidateAvailableBloodProcess.sql
+++ b/onprc_ehr/resources/queries/onprc_ehr/ValidateAvailableBloodProcess.sql
@@ -1,12 +1,10 @@
-/* Returns a single row of data where the date/hour of the Mathematica ABV calculations don't match the current date or hour.
- * If there is Mathematica data from multiple hours, there will be a row of data for each hour of Mathematica data.
- * This is not expected as Mathematica should drop the _public table each hour and the ETL'd data should match.
-* removed comma on line 9 per request
+/*
+ * Return a single line showing latest Mathematica ABV push and the current time, if the data is stale. Otherwise, blank.
+ * Used by onprc_ehr/src/org/labkey/onprc_ehr/notification/AvailableBloodVolumeNotification.java
  */
-SELECT DISTINCT CAST(a.dateCreated AS DATE) AS mmaDate,
-    hour(a.datecreated) AS mmaHour,
-    curdate() AS currentDate,
-    hour(now()) AS currentHour
-FROM ONPRC_EHR.AvailableBloodVolume AS a
-WHERE hour(a.dateCreated) != hour(now())
-   OR CAST(a.dateCreated AS DATE) != curdate()
+
+SELECT DISTINCT
+    MAX(a.DateCreated) AS latestMathematicaABV_data,
+    NOW() AS currentTime
+FROM AvailableBloodVolume a
+WHERE DateCreated < TIMESTAMPADD('SQL_TSI_MINUTE', -55, NOW())

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/AvailableBloodVolumeNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/AvailableBloodVolumeNotification.java
@@ -35,19 +35,19 @@ public class AvailableBloodVolumeNotification extends ColonyAlertsNotification
     @Override
     public String getCronString()
     {
-        return "0 30 7-18 * * ?";
+        return "0 15 6-19 * * ?";
     }
 
     @Override
     public String getScheduleDescription()
     {
-        return "every day at 30 minutes after the hour between 7:30AM and 6:30PM";
+        return "15 minutes after every hour between 06:15 and 19:15.";
     }
 
     @Override
     public String getDescription()
     {
-        return "The report is designed to send an alert if the hourly Available Blood Volume transfer fails.";
+        return "Sends an alert on status of Available Blood Volume data from Mathematica.";
     }
 
     @Override
@@ -71,12 +71,14 @@ public class AvailableBloodVolumeNotification extends ColonyAlertsNotification
         long count = ts.getRowCount();
         if (count > 0)
         {
-            msg.append("<b>" + count + " Available Blood Data is Stale.</b><br>\n");
-            msg.append("<p><a href='" + getExecuteQueryUrl(c, "onprc_ehr", "ValidateAvailableBloodProcess", null) + "'>Click here to view them</a><br>\n\n");
+            msg.append("<b>The available blood volume data from Mathematica is stale.</b><br>\n");
+            msg.append("<p><a href='" + getExecuteQueryUrl(c, "onprc_ehr", "ValidateAvailableBloodProcess", null) + "'>Click here to view labkeyPublic.AvailableBloodVolume.</a><br>\n\n");
             msg.append("</p><br><hr>");
         }
         else
         {
-            msg.append("<b>Excellent: Available Blood Volume is Current !</b><br><hr>");
+            msg.append("The available blood volume data from Mathematica is current.<br><hr>");
+            msg.append("<p><a href='" + getExecuteQueryUrl(c, "onprc_ehr", "ValidateAvailableBloodProcess", null) + "'>Click here to view labkeyPublic.AvailableBloodVolume.</a><br>\n\n");
+            msg.append("</p><br><hr>");
         }
     }}

--- a/onprc_ehr/src/org/labkey/onprc_ehr/notification/AvailableBloodVolumeNotification.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/notification/AvailableBloodVolumeNotification.java
@@ -32,6 +32,10 @@ public class AvailableBloodVolumeNotification extends ColonyAlertsNotification
     {
         return "Available Blood Volume Alert: " + getDateTimeFormat(c).format(new Date());
     }
+    /* From Hugh Crank:
+     * Server mkt7: Runs at :55 from 4:55am to 7:55pm
+     * Server mkt8: Runs at :25 from 4:25am to 7:25pm
+     */
     @Override
     public String getCronString()
     {


### PR DESCRIPTION
#### Rationale
The current ABV process notification generates false positives because MMA's ABV calculations go into PRIMe right before the hour and the way the notification determines if the calculations are stale.

#### Related Pull Requests


#### Changes
