### PR TITLE
Reschedule the ABV ETL

### DIFF
--- a/onprc_ehr/resources/etls/AvailableBlood.xml
+++ b/onprc_ehr/resources/etls/AvailableBlood.xml
@@ -4,7 +4,7 @@
     <description>Copies the Available Blood Volume calculations provided by Mathematica.</description>
     <transforms>
         <transform id="step1">
-            <description>Truncate and populate the Available Blood Volume table</description>
+            <description>Truncate and populate the Available Blood Volume table.</description>
             <source schemaName="labkeyPublic" queryName="AvailableBloodVolume"/>
             <destination schemaName="ONPRC_EHR" queryName="AvailableBloodVolume" targetOption="truncate" />
         </transform>
@@ -13,7 +13,3 @@
             <cron expression="0 1,31 5-20 ? * * *"/> <!-- :01 and :31 after the hour for hours 5am through 8pm -->
         </schedule>
 </etl>
-
-
-
-

--- a/onprc_ehr/resources/etls/AvailableBlood.xml
+++ b/onprc_ehr/resources/etls/AvailableBlood.xml
@@ -1,34 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <etl xmlns="http://labkey.org/etl/xml">
-
     <name>AvailableBloodVolume</name>
-
-    <description>Transfers from the Available Blood Volume Calculation in labkeyPublic.onprc_ehr to Production</description>
-
-
+    <description>Copies the Available Blood Volume calculations provided by Mathematica.</description>
     <transforms>
-
-
         <transform id="step1">
-
-            <description>Truncate and Populate Available Blood Data</description>
-
+            <description>Truncate and populate the Available Blood Volume table</description>
             <source schemaName="labkeyPublic" queryName="AvailableBloodVolume"/>
-
             <destination schemaName="ONPRC_EHR" queryName="AvailableBloodVolume" targetOption="truncate" />
-
         </transform>
-
-
     </transforms>
     	<schedule>
-
-            <cron expression="0 20 0,7,8,9,10,11,12,13,14,15,16,17,18 ? * * *"/>
-
+            <cron expression="0 1,31 5-19 ? * * *"/>
         </schedule>
-
-
 </etl>
 
 

--- a/onprc_ehr/resources/etls/AvailableBlood.xml
+++ b/onprc_ehr/resources/etls/AvailableBlood.xml
@@ -10,7 +10,7 @@
         </transform>
     </transforms>
     	<schedule>
-            <cron expression="0 1,31 5-19 ? * * *"/>
+            <cron expression="0 1,31 5-20 ? * * *"/> <!-- :01 and :31 after the hour for hours 5am through 8pm -->
         </schedule>
 </etl>
 


### PR DESCRIPTION
#### Rationale
CI has rescheduled and increased the frequency of their push of available blood volume calculations to labkeyPublic. This new ABV ETL schedule ensures PRIMe has the latest data as soon as prudent. CI's new schedule, per Hugh Crank:

* Server mkt7: Runs at :55 from 4:55am to 7:55pm
* Server mkt8: Runs at :25 from 4:25am to 7:25pm

Our new schedule copies the data at :01 and :31 minutes after the hour for hours 5am through 8pm (copying CI's final push twice).

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
