### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/onprc_billing/src/org/labkey/onprc_billing/query/BillingAuditProvider.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/query/BillingAuditProvider.java
@@ -42,10 +42,9 @@ public class BillingAuditProvider extends AbstractAuditTypeProvider implements A
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
     }
 
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
+    public BillingAuditProvider()
     {
-        return new BillingAuditDomainKind();
+        super(new BillingAuditDomainKind());
     }
 
     @Override

--- a/sla/src/org/labkey/sla/etl/ETLAuditProvider.java
+++ b/sla/src/org/labkey/sla/etl/ETLAuditProvider.java
@@ -46,8 +46,8 @@ public class ETLAuditProvider extends AbstractAuditTypeProvider implements Audit
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
-    static {
-
+    static
+    {
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED_BY));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_IMPERSONATED_BY));
@@ -56,10 +56,9 @@ public class ETLAuditProvider extends AbstractAuditTypeProvider implements Audit
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
     }
 
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
+    public ETLAuditProvider()
     {
-        return new ETLAuditDomainKind();
+        super(new ETLAuditDomainKind());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Eliminate use of the deprecated `AbstractAuditTypeProvider()` constructor and overrides of `getDomainKind()` in its subclasses; we now always call the constructor that passes in a `DomainKind`.