### PR TITLE
25.7 fb geographic origin bugfix

### DIFF
--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-24.013-24.014.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-24.013-24.014.sql
@@ -3,7 +3,7 @@
 /*
 **
 ** 	Created by
-**      Blasa  		510/8/2025          Process to update birth record;s geogrphic origin data.  The "Genetic Ancestry"
+**      Blasa  		10/8/2025          Process to update birth record;s geogrphic origin data.  The "Genetic Ancestry"
 **                                      geographic_origin information must override the birth's geographic origin values.
 **
 

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-24.013-24.014.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-24.013-24.014.sql
@@ -1,0 +1,74 @@
+
+
+/*
+**
+** 	Created by
+**      Blasa  		510/8/2025          Process to update birth record;s geogrphic origin data.  The "Genetic Ancestry"
+**                                      geographic_origin information must override the birth's geographic origin values.
+**
+
+**
+**
+**
+**
+*/
+
+CREATE Procedure onprc_ehr.p_BirthGeographicOriginUpdates
+
+    as
+
+
+BEGIN
+
+   ----- Process data
+
+  IF exists (select *  From studydataset.c6d202_birth bir, studydataset.c6d512_geneticancestry b where bir.participantid = b.participantid
+    And b.enddate is null
+    and bir.qcstate = 18
+    and b.qcstate = 18
+    And bir.geographic_origin <> b.result
+    And b.result is not null
+              )
+
+
+
+    BEGIN
+
+   ---- Update birth geographic origin
+
+   Update bir
+   set bir.geographic_origin = b.result,
+       bir.modified = getdate(),
+       bir.modifiedby = b.modifiedby    ---- ancestry staff
+
+    From studydataset.c6d202_birth bir, studydataset.c6d512_geneticancestry b
+    where bir.participantid = b.participantid
+    And b.enddate is null
+    And bir.qcstate = 18
+    And b.qcstate = 18
+    And bir.geographic_origin <> b.result
+    And b.result is not null
+
+
+    If @@Error <> 0
+         GoTo Err_Proc
+
+END  ---- if
+
+
+
+
+
+RETURN 0
+
+
+    Err_Proc:
+                    -------Error Generated, process stopped
+	RETURN 1
+
+
+END
+
+GO
+
+

--- a/onprc_ehr/resources/scripts/onprc_ehr/onprc_triggers.js
+++ b/onprc_ehr/resources/scripts/onprc_ehr/onprc_triggers.js
@@ -1348,12 +1348,6 @@ exports.init = function(EHR){
             }
         });
     });
-    EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'demographics', function (helper, scriptErrors, row, oldRow) {
-        if (row.Id && row.geographic_origin)  {
-            //update birth records
-            triggerHelper.updateBirthGeographics(row.Id, row.geographic_origin);
-        }
-    });
 
     //Added: 10-4-2022  R.Blasa
     EHR.Server.TriggerManager.registerHandler(EHR.Server.TriggerManager.Events.COMPLETE, function(event, errors, helper){

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
@@ -129,7 +129,7 @@ public class ONPRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 24.013;
+        return 24.014;
     }
 
     @Override

--- a/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/query/ONPRC_EHRTriggerHelper.java
@@ -2634,54 +2634,6 @@ public class ONPRC_EHRTriggerHelper
     }
 
 
-    public void updateBirthGeographics(String id, String geographic_origin) throws Exception
-    {
-        TableInfo ti = getTableInfo("study", "birth");
-        if (ti == null)
-        {
-            return;
-        }
-
-        Set<FieldKey> keys = new HashSet<>();
-        keys.add(FieldKey.fromString("Id"));
-        keys.add(FieldKey.fromString("geographic_origin"));
-        keys.add(FieldKey.fromString("lsid"));
-        final Map<FieldKey, ColumnInfo> colMap = QueryService.get().getColumns(ti, keys);
-
-
-        final List<Map<String, Object>> toUpdate = new ArrayList<>();
-        final List<Map<String, Object>> oldKeys = new ArrayList<>();
-        TableSelector ts = new TableSelector(ti, colMap.values(), new SimpleFilter(FieldKey.fromString("Id"), id, CompareType.IN), null);
-        ts.forEach(new Selector.ForEachBlock<>()
-        {
-            @Override
-            public void exec(ResultSet object) throws SQLException
-            {
-                ResultsImpl rs = new ResultsImpl(object, colMap);
-                String animalid = rs.getString(FieldKey.fromString("Id"));
-                String origin = rs.getString(FieldKey.fromString("geographic_origin"));
-                String lsid = rs.getString(FieldKey.fromString("lsid"));
-            if (origin != geographic_origin)
-            {
-                Map<String, Object> row = new CaseInsensitiveHashMap<>();
-                row.put("lsid", lsid);
-                row.put("geographic_origin", geographic_origin);
-                Map<String, Object> keyRow = new CaseInsensitiveHashMap<>();
-                keyRow.put("lsid", lsid);
-
-                oldKeys.add(keyRow);
-                toUpdate.add(row);
-
-            }
-            }
-        });
-
-        if (!toUpdate.isEmpty())
-        {
-            TableInfo demographics = getTableInfo("study", "birth");
-            demographics.getUpdateService().updateRows(_user, _container, toUpdate, oldKeys, null, getExtraContext());
-        }
-    }
 
     //Added 9-30-2025
     public String retrieveGeographic_Origin(String Id)


### PR DESCRIPTION
Removed the trigger script that updates the Birth's record geographic orgin values.  The new process will instead run
as a storedprocedure.
