### PR TITLE
Add row count validation to ETL

### DIFF
--- a/GeneticsCore/resources/etls/MHC_Typing.xml
+++ b/GeneticsCore/resources/etls/MHC_Typing.xml
@@ -22,6 +22,21 @@
                 </alternateKeys>
             </destination>
         </transform>
+
+        <transform id="rc" type="TaskrefTransformStep">
+            <taskref ref="org.labkey.primeseq.etl.VerifyRowCount">
+                <settings>
+                    <setting name="sourceRemoteSource" value="PRIMESEQ_MHC"/>
+                    <setting name="sourceSchema" value="geneticscore"/>
+                    <setting name="sourceQuery" value="mhc_data"/>
+                    <setting name="sourceColumn" value="objectId"/>
+
+                    <setting name="destSchema" value="geneticscore"/>
+                    <setting name="destQuery" value="mhc_data"/>
+                    <setting name="destColumn" value="objectId"/>
+                </settings>
+            </taskref>
+        </transform>
     </transforms>
 
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">


### PR DESCRIPTION
This adds an addition check to the existing MHC ETL. After the ETL it compares row counts on the source/destination. I find this to be a useful check to alert if an ETL isnt behaving as expected.