### PR TITLE
25.7 fb form template list order

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/panel/ExamInstructionsPanel.js
+++ b/onprc_ehr/resources/web/onprc_ehr/panel/ExamInstructionsPanel.js
@@ -10,7 +10,7 @@ Ext4.define('ONPRC_EHR.panel.ExamInstructionsPanel', {
     initComponent: function(){
         var buttons = [];
         LDK.Assert.assertNotEmpty('No data entry panel', this.dataEntryPanel);
-        var btnCfg = EHR.DataEntryUtils.getDataEntryFormButton('APPLYFORMTEMPLATE');
+        var btnCfg = EHR.DataEntryUtils.getDataEntryFormButton('APPLYFORMTEMPLATEREV');
         if (btnCfg){
             btnCfg = this.dataEntryPanel.configureButton(btnCfg);
             if (btnCfg){

--- a/onprc_ehr/resources/web/onprc_ehr/window/FormTemplateWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/FormTemplateWindow.js
@@ -282,10 +282,7 @@ Ext4.define('ONPRC_EHR.window.FormTemplateWindow', {
     getRecordDefaults: function(){
         if (this.idSelectionMode == 'none' || this.idSelectionMode == 'multi'){
             var date = this.down('#dateField').getValue();
-            // var idField = this.down('#idField');
             var subjectArray = LDK.Utils.splitIds(this.down('#idField').getValue(), true);
-
-            // var subjectArray = LDK.Utils.splitIds(idField ? idField.getValue() : '');
 
             if (subjectArray.length == 0){
                 subjectArray = [null];

--- a/onprc_ehr/resources/web/onprc_ehr/window/FormTemplateWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/FormTemplateWindow.js
@@ -282,8 +282,10 @@ Ext4.define('ONPRC_EHR.window.FormTemplateWindow', {
     getRecordDefaults: function(){
         if (this.idSelectionMode == 'none' || this.idSelectionMode == 'multi'){
             var date = this.down('#dateField').getValue();
-            var idField = this.down('#idField');
-            var subjectArray = LDK.Utils.splitIds(idField ? idField.getValue() : '');
+            // var idField = this.down('#idField');
+            var subjectArray = LDK.Utils.splitIds(this.down('#idField').getValue(), true);
+
+            // var subjectArray = LDK.Utils.splitIds(idField ? idField.getValue() : '');
 
             if (subjectArray.length == 0){
                 subjectArray = [null];

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/BulkClinicalEntryFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/BulkClinicalEntryFormType.java
@@ -88,6 +88,11 @@ public class BulkClinicalEntryFormType extends TaskForm
         //Added 9-18-2025 R. Blasa
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/panel/ExamInstructionsPanel.js"));
 
+        //Added 11-4-2025 R. Blasa
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/FormTemplateWindow.js"));
+
+
+
     }
 
     @Override

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
@@ -96,6 +96,12 @@ public class ClinicalReportFormType extends TaskForm
         //  Modified: 10-5-2017  R.Blasa  reinstalled 2-12-21
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/model/sources/ClinicalReport.js"));
 
+        //Added 11-4-2025 R. Blasa
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/panel/ExamInstructionsPanel.js"));
+
+        //Added 11-4-2025 R. Blasa
+        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/FormTemplateWindow.js"));
+
 
         //  Added: 7-22-2025  R.Blasa
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/panel/ExamCasesHousingDataEntryPanel.js"));

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
@@ -50,7 +50,7 @@ public class ClinicalReportFormType extends TaskForm
     public ClinicalReportFormType(DataEntryFormContext ctx, Module owner)
     {
         super(ctx, owner, NAME, LABEL, "Clinical", Arrays.<FormSection>asList(
-                new NonStoreFormSection("Instructions", "Instructions", "onprc_ehr-examinstructionspanel", Arrays.asList(ClientDependency.supplierFromPath("ehr/panel/ExamInstructionsPanel.js"))),
+                new NonStoreFormSection("Instructions", "Instructions", "ehr-examinstructionspanel", Arrays.asList(ClientDependency.supplierFromPath("ehr/panel/ExamInstructionsPanel.js"))),
                 new TaskFormSection(),
                 new ExtendedAnimalDetailsFormSection(),
                 new SimpleFormPanelSection("study", "Clinical Remarks", "SOAP", false, EHRService.FORM_SECTION_LOCATION.Tabs),
@@ -95,12 +95,6 @@ public class ClinicalReportFormType extends TaskForm
 
         //  Modified: 10-5-2017  R.Blasa  reinstalled 2-12-21
         addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/model/sources/ClinicalReport.js"));
-
-        //Added 11-4-2025 R. Blasa
-        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/panel/ExamInstructionsPanel.js"));
-
-        //Added 11-4-2025 R. Blasa
-        addClientDependency(ClientDependency.supplierFromPath("onprc_ehr/window/FormTemplateWindow.js"));
 
 
         //  Added: 7-22-2025  R.Blasa

--- a/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/dataentry/ClinicalReportFormType.java
@@ -50,7 +50,7 @@ public class ClinicalReportFormType extends TaskForm
     public ClinicalReportFormType(DataEntryFormContext ctx, Module owner)
     {
         super(ctx, owner, NAME, LABEL, "Clinical", Arrays.<FormSection>asList(
-                new NonStoreFormSection("Instructions", "Instructions", "ehr-examinstructionspanel", Arrays.asList(ClientDependency.supplierFromPath("ehr/panel/ExamInstructionsPanel.js"))),
+                new NonStoreFormSection("Instructions", "Instructions", "onprc_ehr-examinstructionspanel", Arrays.asList(ClientDependency.supplierFromPath("ehr/panel/ExamInstructionsPanel.js"))),
                 new TaskFormSection(),
                 new ExtendedAnimalDetailsFormSection(),
                 new SimpleFormPanelSection("study", "Clinical Remarks", "SOAP", false, EHRService.FORM_SECTION_LOCATION.Tabs),


### PR DESCRIPTION
Updated the form template program to allow Prime users to enter a list of monkey ids in the same
order they were entered.
