### PR TITLE
Add @RetentionYears parameter to ArchiveAuditTables stored procedure

### DIFF
--- a/onprc_ehr/resources/etls/HarvestToPrime_Process.xml
+++ b/onprc_ehr/resources/etls/HarvestToPrime_Process.xml
@@ -71,7 +71,7 @@
 
     <schedule>
 
-        <cron expression="0 0/10 * * * ?"/>
+        <cron expression="0 0/10 1-22 * * ?"/>
 
     </schedule>
 

--- a/onprc_ehr/resources/etls/auditLogArchive.xml
+++ b/onprc_ehr/resources/etls/auditLogArchive.xml
@@ -14,6 +14,7 @@
         <transform id="ArchiveAuditLogs" type="StoredProcedure">
             <description>Archive audit log entries older than @RetentionYears</description>
             <procedure schemaName="audit" procedureName="ArchiveAuditTables">
+                <parameter name="@RetentionYears" value="15"/>
                 <parameter name="@RetentionMonths" value="144" scope="global" override="false"/>
             </procedure>
         </transform>

--- a/onprc_ehr/resources/etls/auditLogArchive.xml
+++ b/onprc_ehr/resources/etls/auditLogArchive.xml
@@ -14,7 +14,7 @@
         <transform id="ArchiveAuditLogs" type="StoredProcedure">
             <description>Archive audit log entries older than @RetentionYears</description>
             <procedure schemaName="audit" procedureName="ArchiveAuditTables">
-                <parameter name="@RetentionYears" value="15" scope="global" override="false"/>
+                <parameter name="@RetentionMonths" value="144" scope="global" override="false"/>
             </procedure>
         </transform>
 

--- a/onprc_ehr/resources/etls/auditLogArchive.xml
+++ b/onprc_ehr/resources/etls/auditLogArchive.xml
@@ -6,12 +6,13 @@
 
     <name>ArchiveAuditLogs</name>
 
-    <description>Executes a Stored Procedure that archives audit log entries older than one year.</description>
+    <description>Archive audit log entries older than @RetentionYears</description>
 
     <transforms>
         <transform id="ArchiveAuditLogs" type="StoredProcedure">
-            <description>Archives audit log entries older than one year.</description>
+            <description>Archive audit log entries older than @RetentionYears</description>
             <procedure schemaName="audit" procedureName="ArchiveAuditTables">
+                <parameter name="@RetentionYears" value="15" scope="global" override="false"/>
             </procedure>
         </transform>
 

--- a/onprc_ehr/resources/etls/auditLogArchive.xml
+++ b/onprc_ehr/resources/etls/auditLogArchive.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--This ETL triggers a stored procedure that archives audit log entries older than one year.
+<!--
+  This ETL triggers a stored procedure that archives audit log entries older than one year. During an initial two-week
+  transition period, this ETL archives one year's worth of audit log entries each night.
  -->
 
 <etl xmlns="http://labkey.org/etl/xml">
@@ -18,7 +20,7 @@
 
     </transforms>
     <schedule>
-        <cron expression="0 0 23 ? * *"/>
+        <cron expression="0 5 23 ? * *"/>
     </schedule>
 
 </etl>

--- a/onprc_ehr/resources/etls/auditLogArchive.xml
+++ b/onprc_ehr/resources/etls/auditLogArchive.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  This ETL triggers a stored procedure that archives audit log entries older than one year. During an initial two-week
-  transition period, this ETL archives one year's worth of audit log entries each night.
+  This ETL triggers a stored procedure that archives audit log entries older than one year. During an initial four-week
+  transition period, this ETL archives six months of audit log entries each night.
  -->
 
 <etl xmlns="http://labkey.org/etl/xml">
 
     <name>ArchiveAuditLogs</name>
 
-    <description>Archive audit log entries older than @RetentionYears</description>
+    <description>Archives audit log entries older than @RetentionYears</description>
 
     <transforms>
         <transform id="ArchiveAuditLogs" type="StoredProcedure">
             <description>Archive audit log entries older than @RetentionYears</description>
             <procedure schemaName="audit" procedureName="ArchiveAuditTables">
-                <parameter name="@RetentionYears" value="15"/>
                 <parameter name="@RetentionMonths" value="144" scope="global" override="false"/>
             </procedure>
         </transform>

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -3,6 +3,7 @@ SET QUOTED_IDENTIFIER ON;
 GO
 
 ALTER PROCEDURE [audit].[ArchiveAuditTables] (
+    @RetentionYears INT,
     @RetentionMonths INT OUTPUT
 )
 AS
@@ -17,7 +18,7 @@ BEGIN
     SET @RetentionMonths = CASE WHEN @RetentionMonths - 6 > 12 THEN @RetentionMonths - 6 ELSE 12 END;
     PRINT N'Archiving audit logs older than ' + CAST(@RetentionMonths AS NVARCHAR(3)) + N' months old'
 
-    DECLARE @CutoffDate DATETIME = DATEADD(YEAR, -@RetentionMonths, GETDATE());
+    DECLARE @CutoffDate DATETIME = DATEADD(MONTH, -@RetentionMonths, GETDATE());
 
 
     -- Validate if source database exists

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -34,7 +34,29 @@ BEGIN
         RETURN;
     END
 
-    -- Create RetentionMonths column in ArchiveAuditLog table if it doesn't exist
+    -- Create ArchiveAuditLog table if not exists (useful for testing)
+    DECLARE @CreateLogTableSQL NVARCHAR(MAX) = '
+    IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@DestDB) + '.INFORMATION_SCHEMA.TABLES
+                   WHERE TABLE_SCHEMA = ''dbo'' AND TABLE_NAME = ''ArchiveAuditLog'')
+    BEGIN
+        EXEC(''USE ' + QUOTENAME(@DestDB) + ';
+        CREATE TABLE dbo.ArchiveAuditLog (
+            LogID INT IDENTITY(1,1) NOT NULL,
+            TableName NVARCHAR(128) NOT NULL,
+            Operation NVARCHAR(50) NOT NULL,
+            StartTime DATETIME NOT NULL,
+            EndTime DATETIME NULL,
+            Status NVARCHAR(50) NULL,
+            RecordsProcessed INT NULL,
+            ErrorMessage NVARCHAR(MAX) NULL,
+            RetentionMonths INT NULL,
+            CONSTRAINT PK_ArchiveAuditLog PRIMARY KEY (LogID)
+        )'');
+    END';
+
+    EXEC sp_executesql @CreateLogTableSQL;
+
+    -- Create RetentionMonths column in ArchiveAuditLog table if not exist
     DECLARE @CreateRetentionColumnSQL NVARCHAR(MAX) = '
     IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@DestDB) + '.INFORMATION_SCHEMA.COLUMNS
                WHERE TABLE_SCHEMA = ''dbo''

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -1,0 +1,202 @@
+GO
+SET QUOTED_IDENTIFIER ON;
+GO
+
+ALTER PROCEDURE [audit].[ArchiveAuditTables] (
+    @RetentionYears INT OUTPUT
+)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- Declare variables
+    DECLARE @SourceDB NVARCHAR(128) = DB_NAME(),
+            @DestDB NVARCHAR(128) = 'labkey_audit',
+            @SchemaName NVARCHAR(128) = 'audit';
+
+    SET @RetentionYears = CASE WHEN @RetentionYears - 1 > 1 THEN @RetentionYears - 1 ELSE 1 END;
+    PRINT 'Archiving audit logs older than ' + @RetentionYears; + ' years old''
+
+    DECLARE @CutoffDate DATETIME = DATEADD(YEAR, -@RetentionYears, GETDATE());
+
+
+    -- Validate if source database exists
+    IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = @SourceDB)
+    BEGIN
+        RAISERROR('Source database "%s" does not exist.', 16, 1, @SourceDB);
+        RETURN;
+    END
+
+    -- Validate if destination database exists
+    IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = @DestDB)
+    BEGIN
+        RAISERROR('Destination database "%s" does not exist.', 16, 1, @DestDB);
+        RETURN;
+    END
+
+    -- Create ArchiveAuditLog table if not exists
+    DECLARE @CreateLogTableSQL NVARCHAR(MAX) = '
+        IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@DestDB) + '.INFORMATION_SCHEMA.TABLES
+                   WHERE TABLE_SCHEMA = ''dbo'' AND TABLE_NAME = ''ArchiveAuditLog'')
+        BEGIN
+            EXEC(''USE ' + QUOTENAME(@DestDB) + ';
+            CREATE TABLE dbo.ArchiveAuditLog (
+                LogID INT IDENTITY(1,1) NOT NULL,
+                TableName NVARCHAR(128) NOT NULL,
+                Operation NVARCHAR(50) NOT NULL,
+                StartTime DATETIME NOT NULL,
+                EndTime DATETIME NULL,
+                Status NVARCHAR(50) NULL,
+                RecordsProcessed INT NULL,
+                ErrorMessage NVARCHAR(MAX) NULL,
+                RetentionYears INT NULL,
+                CONSTRAINT PK_ArchiveAuditLog PRIMARY KEY (LogID)
+            )'');
+        END';
+
+    EXEC sp_executesql @CreateLogTableSQL;
+
+    -- Validate if source schema exists
+    DECLARE @SourceSchemaCheck NVARCHAR(MAX) = '
+        IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@SourceDB) + '.sys.schemas WHERE name = ''' + @SchemaName + ''')
+        BEGIN
+            RAISERROR(''Source schema "%s" does not exist'', 16, 1, ''' + @SchemaName + ''');
+        END';
+
+    EXEC sp_executesql @SourceSchemaCheck;
+
+    -- Create destination schema if not exists
+    DECLARE @CreateDestSchemaSQL NVARCHAR(MAX) = '
+        IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@DestDB) + '.sys.schemas WHERE name = ''' + @SchemaName + ''')
+        BEGIN
+            EXEC ' + QUOTENAME(@DestDB) + '.sys.sp_executesql N''CREATE SCHEMA ' + QUOTENAME(@SchemaName) + ''';
+        END';
+
+    EXEC sp_executesql @CreateDestSchemaSQL;
+
+    -- Get list of tables to process
+    CREATE TABLE #TableList (TableName NVARCHAR(128));
+
+    DECLARE @GetTablesSQL NVARCHAR(MAX) = '
+        INSERT INTO #TableList
+        SELECT TABLE_NAME
+        FROM ' + QUOTENAME(@SourceDB) + '.INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = ''' + @SchemaName + '''';
+
+    EXEC sp_executesql @GetTablesSQL;
+
+    DECLARE @CurrentTable NVARCHAR(128);
+    DECLARE TableCursor CURSOR LOCAL FAST_FORWARD FOR
+    SELECT TableName FROM #TableList;
+
+    OPEN TableCursor;
+    FETCH NEXT FROM TableCursor INTO @CurrentTable;
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        DECLARE @LogID INT;
+
+        -- Log the start of archiving for current table
+        DECLARE @InsertLogSQL NVARCHAR(MAX) = '
+            USE ' + QUOTENAME(@DestDB) + ';
+            INSERT INTO dbo.ArchiveAuditLog
+                (TableName, Operation, StartTime, Status, RetentionYears)
+            VALUES (''' + @CurrentTable + ''', ''Archive'', GETDATE(), ''Started'', ' + CAST(@RetentionYears AS NVARCHAR(10)) + ');
+            SELECT @LogIDOUT = SCOPE_IDENTITY();';
+
+        EXEC sp_executesql @InsertLogSQL, N'@LogIDOUT INT OUTPUT', @LogIDOUT = @LogID OUTPUT;
+
+        BEGIN TRY
+            DECLARE @FullSourceTable NVARCHAR(512) = QUOTENAME(@SourceDB) + '.' + QUOTENAME(@SchemaName) + '.' + QUOTENAME(@CurrentTable),
+                    @FullDestTable NVARCHAR(512) = QUOTENAME(@DestDB) + '.' + QUOTENAME(@SchemaName) + '.' + QUOTENAME(@CurrentTable),
+                    @ColumnList NVARCHAR(MAX) = '';
+
+            -- Create destination table if it doesn't exist
+            DECLARE @CheckTableSQL NVARCHAR(MAX) = '
+                IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@DestDB) + '.INFORMATION_SCHEMA.TABLES
+                    WHERE TABLE_SCHEMA = ''' + @SchemaName + '''
+                    AND TABLE_NAME = ''' + @CurrentTable + ''')
+                BEGIN
+                    SELECT * INTO ' + @FullDestTable + '
+                    FROM ' + @FullSourceTable + '
+                    WHERE 1 = 0;
+                END';
+
+            EXEC sp_executesql @CheckTableSQL;
+
+            -- Get column list (excluding identity columns)
+            CREATE TABLE #Columns (ColumnName NVARCHAR(128), IsIdentity BIT);
+
+            DECLARE @GetColumnsSQL NVARCHAR(MAX) = '
+                INSERT INTO #Columns
+                SELECT c.name AS ColumnName,
+                COLUMNPROPERTY(OBJECT_ID(''' + @FullSourceTable + '''), c.name, ''IsIdentity'') AS IsIdentity
+                FROM ' + QUOTENAME(@SourceDB) + '.sys.columns c
+                JOIN ' + QUOTENAME(@SourceDB) + '.sys.tables t ON c.object_id = t.object_id
+                JOIN ' + QUOTENAME(@SourceDB) + '.sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = ''' + @SchemaName + '''
+                AND t.name = ''' + @CurrentTable + '''';
+
+            EXEC sp_executesql @GetColumnsSQL;
+
+            SELECT @ColumnList = STRING_AGG(QUOTENAME(ColumnName), ', ')
+            FROM #Columns
+            WHERE IsIdentity = 0;
+
+            DROP TABLE #Columns;
+
+            -- Archive data
+            BEGIN TRANSACTION;
+
+                DECLARE @ArchiveSQL NVARCHAR(MAX) = '
+                    INSERT INTO ' + @FullDestTable + ' (' + @ColumnList + ')
+                    SELECT ' + @ColumnList + '
+                    FROM ' + @FullSourceTable + '
+                    WHERE Created < @CutoffDate;
+
+                    DECLARE @RecordsInserted INT = @@ROWCOUNT;
+
+                    DELETE FROM ' + @FullSourceTable + '
+                    WHERE Created < @CutoffDate;
+
+                    DECLARE @RecordsDeleted INT = @@ROWCOUNT;
+
+                    UPDATE ' + QUOTENAME(@DestDB) + '.dbo.ArchiveAuditLog
+                    SET RecordsProcessed = @RecordsInserted,
+                        EndTime = GETDATE(),
+                        Status = ''Success''
+                    WHERE LogID = @LogID;';
+
+                EXEC sp_executesql @ArchiveSQL,
+                    N'@CutoffDate DATETIME, @LogID INT',
+                    @CutoffDate = @CutoffDate,
+                    @LogID = @LogID;
+
+            COMMIT TRANSACTION;
+        END TRY
+        BEGIN CATCH
+            IF @@TRANCOUNT > 0
+                ROLLBACK TRANSACTION;
+
+                DECLARE @ErrorMessage NVARCHAR(4000) = 'Error archiving ' + @CurrentTable + ': ' + ERROR_MESSAGE();
+
+                DECLARE @UpdateLogSQL NVARCHAR(MAX) = '
+                    UPDATE ' + QUOTENAME(@DestDB) + '.dbo.ArchiveAuditLog
+                    SET EndTime = GETDATE(),
+                        Status = ''Error'',
+                        ErrorMessage = @ErrorMessage
+                    WHERE LogID = ' + CAST(@LogID AS NVARCHAR(10));
+
+                EXEC sp_executesql @UpdateLogSQL, N'@ErrorMessage NVARCHAR(4000)', @ErrorMessage = @ErrorMessage;
+
+                PRINT @ErrorMessage;
+        END CATCH
+
+        FETCH NEXT FROM TableCursor INTO @CurrentTable;
+    END
+
+    CLOSE TableCursor;
+    DEALLOCATE TableCursor;
+
+    DROP TABLE #TableList;
+END

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -15,7 +15,7 @@ BEGIN
             @SchemaName NVARCHAR(128) = 'audit';
 
     SET @RetentionYears = CASE WHEN @RetentionYears - 1 > 1 THEN @RetentionYears - 1 ELSE 1 END;
-    PRINT 'Archiving audit logs older than ' + @RetentionYears + ' years old'
+    PRINT N'Archiving audit logs older than ' + CAST(@RetentionYears AS NVARCHAR(3)) + N' years old'
 
     DECLARE @CutoffDate DATETIME = DATEADD(YEAR, -@RetentionYears, GETDATE());
 

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -15,7 +15,7 @@ BEGIN
             @SchemaName NVARCHAR(128) = 'audit';
 
     SET @RetentionYears = CASE WHEN @RetentionYears - 1 > 1 THEN @RetentionYears - 1 ELSE 1 END;
-    PRINT 'Archiving audit logs older than ' + @RetentionYears; + ' years old''
+    PRINT 'Archiving audit logs older than ' + @RetentionYears; + ' years old'
 
     DECLARE @CutoffDate DATETIME = DATEADD(YEAR, -@RetentionYears, GETDATE());
 

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -3,7 +3,6 @@ SET QUOTED_IDENTIFIER ON;
 GO
 
 ALTER PROCEDURE [audit].[ArchiveAuditTables] (
-    @RetentionYears INT,
     @RetentionMonths INT OUTPUT
 )
 AS
@@ -35,27 +34,20 @@ BEGIN
         RETURN;
     END
 
-    -- Create ArchiveAuditLog table if not exists
-    DECLARE @CreateLogTableSQL NVARCHAR(MAX) = '
-        IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@DestDB) + '.INFORMATION_SCHEMA.TABLES
-                   WHERE TABLE_SCHEMA = ''dbo'' AND TABLE_NAME = ''ArchiveAuditLog'')
-        BEGIN
-            EXEC(''USE ' + QUOTENAME(@DestDB) + ';
-            CREATE TABLE dbo.ArchiveAuditLog (
-                LogID INT IDENTITY(1,1) NOT NULL,
-                TableName NVARCHAR(128) NOT NULL,
-                Operation NVARCHAR(50) NOT NULL,
-                StartTime DATETIME NOT NULL,
-                EndTime DATETIME NULL,
-                Status NVARCHAR(50) NULL,
-                RecordsProcessed INT NULL,
-                ErrorMessage NVARCHAR(MAX) NULL,
-                RetentionMonths INT NULL,
-                CONSTRAINT PK_ArchiveAuditLog PRIMARY KEY (LogID)
-            )'');
-        END';
+    -- Create RetentionMonths column in ArchiveAuditLog table if it doesn't exist
+    DECLARE @CreateRetentionColumnSQL NVARCHAR(MAX) = '
+    IF NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(@DestDB) + '.INFORMATION_SCHEMA.COLUMNS
+               WHERE TABLE_SCHEMA = ''dbo''
+                 AND TABLE_NAME = ''ArchiveAuditLog''
+                 AND COLUMN_NAME = ''RetentionMonths'')
+    BEGIN
+        EXEC(''USE ' + QUOTENAME(@DestDB) + ';
+        ALTER TABLE dbo.ArchiveAuditLog
+            ADD RetentionMonths INT NULL
+        '');
+    END';
 
-    EXEC sp_executesql @CreateLogTableSQL;
+    EXEC sp_executesql @CreateRetentionColumnSQL;
 
     -- Validate if source schema exists
     DECLARE @SourceSchemaCheck NVARCHAR(MAX) = '

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -15,7 +15,7 @@ BEGIN
             @SchemaName NVARCHAR(128) = 'audit';
 
     SET @RetentionYears = CASE WHEN @RetentionYears - 1 > 1 THEN @RetentionYears - 1 ELSE 1 END;
-    PRINT 'Archiving audit logs older than ' + @RetentionYears; + ' years old'
+    PRINT 'Archiving audit logs older than ' + @RetentionYears + ' years old'
 
     DECLARE @CutoffDate DATETIME = DATEADD(YEAR, -@RetentionYears, GETDATE());
 

--- a/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
+++ b/onprc_ehr/resources/schemas/dbscripts/sqlserver/onprc_ehr-25.002-25.003.sql
@@ -3,7 +3,7 @@ SET QUOTED_IDENTIFIER ON;
 GO
 
 ALTER PROCEDURE [audit].[ArchiveAuditTables] (
-    @RetentionYears INT OUTPUT
+    @RetentionMonths INT OUTPUT
 )
 AS
 BEGIN
@@ -14,10 +14,10 @@ BEGIN
             @DestDB NVARCHAR(128) = 'labkey_audit',
             @SchemaName NVARCHAR(128) = 'audit';
 
-    SET @RetentionYears = CASE WHEN @RetentionYears - 1 > 1 THEN @RetentionYears - 1 ELSE 1 END;
-    PRINT N'Archiving audit logs older than ' + CAST(@RetentionYears AS NVARCHAR(3)) + N' years old'
+    SET @RetentionMonths = CASE WHEN @RetentionMonths - 6 > 12 THEN @RetentionMonths - 6 ELSE 12 END;
+    PRINT N'Archiving audit logs older than ' + CAST(@RetentionMonths AS NVARCHAR(3)) + N' months old'
 
-    DECLARE @CutoffDate DATETIME = DATEADD(YEAR, -@RetentionYears, GETDATE());
+    DECLARE @CutoffDate DATETIME = DATEADD(YEAR, -@RetentionMonths, GETDATE());
 
 
     -- Validate if source database exists
@@ -49,7 +49,7 @@ BEGIN
                 Status NVARCHAR(50) NULL,
                 RecordsProcessed INT NULL,
                 ErrorMessage NVARCHAR(MAX) NULL,
-                RetentionYears INT NULL,
+                RetentionMonths INT NULL,
                 CONSTRAINT PK_ArchiveAuditLog PRIMARY KEY (LogID)
             )'');
         END';
@@ -100,8 +100,8 @@ BEGIN
         DECLARE @InsertLogSQL NVARCHAR(MAX) = '
             USE ' + QUOTENAME(@DestDB) + ';
             INSERT INTO dbo.ArchiveAuditLog
-                (TableName, Operation, StartTime, Status, RetentionYears)
-            VALUES (''' + @CurrentTable + ''', ''Archive'', GETDATE(), ''Started'', ' + CAST(@RetentionYears AS NVARCHAR(10)) + ');
+                (TableName, Operation, StartTime, Status, RetentionMonths)
+            VALUES (''' + @CurrentTable + ''', ''Archive'', GETDATE(), ''Started'', ' + CAST(@RetentionMonths AS NVARCHAR(10)) + ');
             SELECT @LogIDOUT = SCOPE_IDENTITY();';
 
         EXEC sp_executesql @InsertLogSQL, N'@LogIDOUT INT OUTPUT', @LogIDOUT = @LogID OUTPUT;

--- a/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/ONPRC_EHRModule.java
@@ -124,7 +124,7 @@ public class ONPRC_EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.002;
+        return 25.003;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The ArchiveAuditTables stored procedure effectively prevents PRIMe from being used when it runs by blocking writes to the audit log when a table is being archived. 

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/1465
* https://github.com/LabKey/onprcEHRModules/pull/1528

#### Changes
* Create a @RetentionMonths parameter and archive data older than the value. 
* Decrement @RetentionYears each run, starting at 144 and stopping at 12.
