### PR TITLE
Continue adopting FileLike instead of File or Path

### DIFF
--- a/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingController.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/ONPRC_BillingController.java
@@ -43,11 +43,13 @@ import org.labkey.api.view.NavTree;
 import org.labkey.onprc_billing.notification.BillingValidationNotification;
 import org.labkey.onprc_billing.pipeline.BillingPipelineJob;
 import org.labkey.onprc_billing.security.ONPRCBillingAdminPermission;
+import org.labkey.vfs.FileLike;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,14 +70,14 @@ public class ONPRC_BillingController extends SpringActionController
     public static class RunBillingPipelineAction extends MutatingApiAction<BillingPipelineForm>
     {
         @Override
-        public ApiResponse execute(BillingPipelineForm form, BindException errors) throws PipelineJobException
+        public ApiResponse execute(BillingPipelineForm form, BindException errors) throws IOException
         {
             Map<String, Object> resultProperties = new HashMap<>();
 
             try
             {
                 PipeRoot pipelineRoot = PipelineService.get().findPipelineRoot(getContainer());
-                File analysisDir = BillingPipelineJob.createAnalysisDir(pipelineRoot, form.getProtocolName());
+                FileLike analysisDir = BillingPipelineJob.createAnalysisDir(pipelineRoot, form.getProtocolName());
                 PipelineService.get().queueJob(new BillingPipelineJob(getContainer(), getUser(), getViewContext().getActionURL(), pipelineRoot, analysisDir, form));
 
                 resultProperties.put("success", true);

--- a/onprc_billing/src/org/labkey/onprc_billing/pipeline/BillingPipelineJob.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/pipeline/BillingPipelineJob.java
@@ -30,8 +30,9 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.onprc_billing.ONPRC_BillingController;
+import org.labkey.vfs.FileLike;
 
-import java.io.File;
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -42,7 +43,6 @@ import java.util.Date;
  */
 public class BillingPipelineJob extends PipelineJob implements BillingPipelineJobSupport
 {
-    private File _analysisDir;
     private ONPRC_BillingController.BillingPipelineForm _form;
 
     // For deserialization
@@ -50,25 +50,23 @@ public class BillingPipelineJob extends PipelineJob implements BillingPipelineJo
     {
     }
 
-    public BillingPipelineJob(Container c, User user, ActionURL url, PipeRoot pipeRoot, File analysisDir, ONPRC_BillingController.BillingPipelineForm form)
+    public BillingPipelineJob(Container c, User user, ActionURL url, PipeRoot pipeRoot, FileLike analysisDir, ONPRC_BillingController.BillingPipelineForm form)
     {
         super(null, new ViewBackgroundInfo(c, user, url), pipeRoot);
-
-        _analysisDir = analysisDir;
-        setLogFile(new File(analysisDir, FileUtil.makeFileNameWithTimestamp("billingPipeline", "log")));
+        setLogFile(analysisDir.resolveChild(FileUtil.makeFileNameWithTimestamp("billingPipeline", "log")));
         _form = form;
     }
 
-    public static File createAnalysisDir(PipeRoot pipeRoot, String name) throws PipelineValidationException
+    public static FileLike createAnalysisDir(PipeRoot pipeRoot, String name) throws PipelineValidationException, IOException
     {
         String trialName = FileUtil.makeLegalName(name);
-        File analysisDir = new File(pipeRoot.getRootPath(), trialName);
+        FileLike analysisDir = pipeRoot.resolvePathToFileLike(trialName);
         int suffix = 0;
         while (analysisDir.exists())
         {
             suffix++;
             trialName = FileUtil.makeLegalName(name) + "." + suffix;
-            analysisDir = new File(pipeRoot.getRootPath(), trialName);
+            analysisDir = pipeRoot.resolvePathToFileLike(trialName);
         }
 
         analysisDir.mkdirs();
@@ -89,7 +87,7 @@ public class BillingPipelineJob extends PipelineJob implements BillingPipelineJo
     }
 
     @Override
-    public TaskPipeline getTaskPipeline()
+    public TaskPipeline<?> getTaskPipeline()
     {
         return PipelineJobService.get().getTaskPipeline(new TaskId(BillingPipelineJob.class));
     }
@@ -97,15 +95,13 @@ public class BillingPipelineJob extends PipelineJob implements BillingPipelineJo
     @Override
     public Date getStartDate()
     {
-        Date ret = _form.getStartDate() == null ? null : DateUtils.truncate(_form.getStartDate(), Calendar.DATE);
-        return ret;
+        return _form.getStartDate() == null ? null : DateUtils.truncate(_form.getStartDate(), Calendar.DATE);
     }
 
     @Override
     public Date getEndDate()
     {
-        Date ret = _form.getEndDate() == null ? null : DateUtils.truncate(_form.getEndDate(), Calendar.DATE);
-        return ret;
+        return _form.getEndDate() == null ? null : DateUtils.truncate(_form.getEndDate(), Calendar.DATE);
     }
 
     @Override
@@ -118,11 +114,5 @@ public class BillingPipelineJob extends PipelineJob implements BillingPipelineJo
     public String getName()
     {
         return _form.getProtocolName();
-    }
-
-    @Override
-    public File getAnalysisDir()
-    {
-        return _analysisDir;
     }
 }

--- a/onprc_billing/src/org/labkey/onprc_billing/pipeline/BillingPipelineJobSupport.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/pipeline/BillingPipelineJobSupport.java
@@ -32,6 +32,4 @@ public interface BillingPipelineJobSupport
     String getComment();
 
     String getName();
-
-    File getAnalysisDir();
 }


### PR DESCRIPTION
#### Rationale
We can continue to strengthen our protections against path traversal attacks and start phasing out deprecated and overloaded methods that take or return Files or Paths. 

### Related Pull Requests
- https://github.com/LabKey/platform/pull/7211

#### Changes
- Eliminate some overloaded, deprecated versions of methods taking `File` or `Path`
- Convert `LocalDirectory` and `WorkDirectory` to `FileLike`
- Use `FileLike` more consistently for transform scripts