### PR TITLE
Add master problems to vet assignment main query

### DIFF
--- a/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
+++ b/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
@@ -2,34 +2,24 @@
 study.demographicsAssignedVet
 
 * Returns one or more assigned vets per animal ID
-* Note to future self: don't be tempted to add more fields to this view. It will likely
-  result in additional rows per animal as they won't be distinct.
-
+* Note to future self: be very careful when adding more fields to this view. It can easily
+  result in additional rows per animal if they're distinct.
  */
 
--- Step 1: Find the minimum matchedRule for each ID
-WITH MinMatchedRules AS (
-    SELECT
-        VAF2.Id,
-        MIN(VAF2.matchedRule) AS MinRule
-    FROM
-        vetAssignment_Filter AS VAF2
-    GROUP BY
-        VAF2.Id
+SELECT
+    f.Id,
+    f.AssignedVet,
+    f.AssignmentType,
+    GROUP_CONCAT(
+            CASE WHEN f.matchedRule = 0 THEN f.ActiveMasterProblems ELSE NULL END,
+            ', '
+    ) AS MasterProblems,
+    f.Area,
+    f.Room
+FROM vetAssignment_filter f
+WHERE f.matchedRule = (
+    SELECT min(matchedRule)
+    FROM vetAssignment_filter sub
+    WHERE sub.Id = f.Id
 )
-
--- Step 2: Join the original table with the filtered minimum matched rules
-SELECT DISTINCT
-    VAF1.Id,
-    VAF1.AssignedVet,
-    VAF1.AssignmentType,
-    VAF1.Room,
-    VAF1.Area,
-    VAF1.Species
-
-FROM
-    vetAssignment_Filter AS VAF1
-        INNER JOIN
-    MinMatchedRules AS MMR
-    ON VAF1.Id = MMR.Id
-        AND VAF1.matchedRule = MMR.MinRule
+GROUP BY f.Id, f.AssignedVet, f.AssignmentType, f.Area, f.Room

--- a/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
+++ b/onprc_ehr/resources/queries/study/demographicsAssignedVet.sql
@@ -2,34 +2,29 @@
 study.demographicsAssignedVet
 
 * Returns one or more assigned vets per animal ID
-* Note to future self: don't be tempted to add more fields to this view. It will likely
-  result in additional rows per animal as they won't be distinct.
-
+* Note to future self: be very careful when adding more fields to this view. It can easily
+  result in additional rows per animal if they're distinct.
  */
 
 -- Step 1: Find the minimum matchedRule for each ID
-WITH MinMatchedRules AS (
-    SELECT
-        VAF2.Id,
-        MIN(VAF2.matchedRule) AS MinRule
-    FROM
-        vetAssignment_Filter AS VAF2
-    GROUP BY
-        VAF2.Id
-)
+WITH MinMatchedRules AS (SELECT Id,
+                                min(matchedRule) AS rule
+                            FROM vetAssignment_Filter
+                            GROUP BY Id)
 
 -- Step 2: Join the original table with the filtered minimum matched rules
-SELECT DISTINCT
-    VAF1.Id,
-    VAF1.AssignedVet,
-    VAF1.AssignmentType,
-    VAF1.Room,
-    VAF1.Area,
-    VAF1.Species
+SELECT DISTINCT f.Id,
+    f.AssignedVet,
+    f.AssignmentType,
+    p.MasterProblems,
+    f.Area,
+    f.Room
 
-FROM
-    vetAssignment_Filter AS VAF1
-        INNER JOIN
-    MinMatchedRules AS MMR
-    ON VAF1.Id = MMR.Id
-        AND VAF1.matchedRule = MMR.MinRule
+FROM vetAssignment_Filter f
+     JOIN MinMatchedRules r ON f.Id = r.Id AND f.matchedRule = r.rule
+     LEFT JOIN (SELECT Id,
+                    AssignedVet,
+                    GROUP_CONCAT(ActiveMasterProblems, ',') AS MasterProblems
+                FROM vetAssignment_filter
+                WHERE matchedRule = 0
+                GROUP BY Id, AssignedVet) p ON p.Id = f.Id AND p.AssignedVet = f.AssignedVet


### PR DESCRIPTION
#### Rationale
It can be difficult to distinguish multiple open cases without seeing their associated master problems. This PR adds the master problems to the main assigned vet view.

#### Related Pull Requests
* (https://github.com/LabKey/onprcEHRModules/pull/1467)

#### Changes
* Refactored `study.demographicsAssignedVet.sql` to add master problems while maintaining performance.
