### PR TITLE
Update to ChargeRate.js and active view xml to have end time at the …

### DIFF
--- a/onprc_billing/resources/queries/onprc_billing/chargeRates.js
+++ b/onprc_billing/resources/queries/onprc_billing/chargeRates.js
@@ -16,10 +16,18 @@ function beforeUpdate(row, errors){
 
 function beforeUpsert(row, errors){
     if (row.startDate){
+        // normalize to date-only (00:00)
         row.startDate = ldkUtils.removeTimeFromDate(row.startDate);
     }
 
     if (row.endDate){
-        row.endDate = ldkUtils.removeTimeFromDate(row.endDate);
+        // normalize to date-only first
+        var cleanDate = ldkUtils.removeTimeFromDate(row.endDate);
+
+        // create a new date object set to 23:59
+        var endOfDay = new Date(cleanDate);
+        endOfDay.setHours(23, 59, 0, 0);
+
+        row.endDate = endOfDay;
     }
 }

--- a/onprc_billing/resources/queries/onprc_billing/chargeRates/Active Rates.qview.xml
+++ b/onprc_billing/resources/queries/onprc_billing/chargeRates/Active Rates.qview.xml
@@ -4,6 +4,6 @@
         <sort column="startDate" descending="true"/>
     </sorts>
     <filters>
-        <filter column="enddateCoalesced" operator="dategte" value="-0d"/>
+        <filter column="enddateCoalesced" operator="dategte" value="-0d"/> <!--changed to overwright is Active-->
     </filters>
 </customView>


### PR DESCRIPTION
…end of the day

#### Rationale
Update to change the logic so the end date of a charge item is the end of the day.  Also changed the logic for active charges to use coaleasced

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### 
ChangeschargeRate.js
active Rate.qview.xml
