### PR TITLE
Make the search more specific

### DIFF
--- a/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
+++ b/onprc_ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_RestrictedIssueTest.java
@@ -288,7 +288,7 @@ public class ONPRC_RestrictedIssueTest extends BaseWebDriverTest implements Sqls
         final String ISSUE_2 = detailsPage.getIssueId();
 
         SearchHelper searchHelper = new SearchHelper(this);
-        SearchResultsPage resultsPage = searchHelper.searchFor("Restricted issue search test");
+        SearchResultsPage resultsPage = searchHelper.searchFor("\"Restricted issue search test\"");
 
         // verify that we can return links even if the user doesn't have permission to view a restricted issue
         Assert.assertTrue("Number of search results not expected", resultsPage.getResults().size() == 2);


### PR DESCRIPTION
#### Rationale
The test was matching more search results than intended, change the search term so just the 2 issues are returned.