### PR TITLE
Stop passing SecurityPolicy parameter to Role.isApplicable()

### DIFF
--- a/onprc_ehr/src/org/labkey/onprc_ehr/security/ONPRC_EHRCMUAdministrationRole.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/security/ONPRC_EHRCMUAdministrationRole.java
@@ -18,7 +18,6 @@ package org.labkey.onprc_ehr.security;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -43,7 +42,7 @@ public class ONPRC_EHRCMUAdministrationRole extends AbstractRole
         );
     }
     @Override
-    public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
+    public boolean isApplicable(SecurableResource resource)
     {
         return resource instanceof Container ? ((Container)resource).getActiveModules().contains(ModuleLoader.getInstance().getModule(ONPRC_EHRModule.class)) : false;
     }

--- a/onprc_ehr/src/org/labkey/onprc_ehr/security/ONPRC_EHRCMUMedicationAdministrationRole.java
+++ b/onprc_ehr/src/org/labkey/onprc_ehr/security/ONPRC_EHRCMUMedicationAdministrationRole.java
@@ -18,7 +18,6 @@ package org.labkey.onprc_ehr.security;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -42,7 +41,7 @@ public class ONPRC_EHRCMUMedicationAdministrationRole extends AbstractRole
         );
     }
     @Override
-    public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
+    public boolean isApplicable(SecurableResource resource)
     {
         return resource instanceof Container ? ((Container)resource).getActiveModules().contains(ModuleLoader.getInstance().getModule(ONPRC_EHRModule.class)) : false;
     }


### PR DESCRIPTION
#### Rationale
No implementation uses this parameter