### PR TITLE
Fix typo in URL

### DIFF
--- a/GeneticsCore/resources/views/mhcDataDashboard.html
+++ b/GeneticsCore/resources/views/mhcDataDashboard.html
@@ -66,7 +66,7 @@
                             'query.viewName': 'SBT Information',
                             'query.readset~nonblank': null,
                             'query.readset/status~isblank': null,
-                            'query.numCachedResults~gt': 0,
+                            'query.numCachedResults~eq': 0,
                         })
                     },{
                         name: 'Readsets Without Alignments',


### PR DESCRIPTION
This PR corrects a minor typo in a URL on a page related to MHC typing data