### PR TITLE
Fix stored XSS in finance notification charge summary report

### DIFF
--- a/onprc_billing/src/org/labkey/onprc_billing/notification/DCMFinanceNotification.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/notification/DCMFinanceNotification.java
@@ -2,6 +2,7 @@ package org.labkey.onprc_billing.notification;
 
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.data.Container;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.onprc_billing.ONPRC_BillingManager;
 import org.labkey.onprc_billing.ONPRC_BillingSchema;
 
@@ -57,7 +58,7 @@ public class DCMFinanceNotification extends FinanceNotification
             Container container = containerMap.get(category);
 
             String url = getExecuteQueryUrl(container, ONPRC_BillingSchema.NAME, categoryToQuery.get(category), null) + "&query.param.StartDate=" + getDateFormat(c).format(start.getTime()) + "&query.param.EndDate=" + getDateFormat(c).format(endDate.getTime());
-            msg.append("<tr><td><a href='" + url + "'>" + category + "</a></td><td>" + totalsMap.get("total") + "</td><td>" + _dollarFormat.format(totalsMap.get("totalCost")) + "</td></tr>");
+            msg.append("<tr><td><a href='" + PageFlowUtil.filter(url) + "'>" + PageFlowUtil.filter(category) + "</a></td><td>" + totalsMap.get("total") + "</td><td>" + _dollarFormat.format(totalsMap.get("totalCost")) + "</td></tr>");
         }
         msg.append("</table><br><br>");
 
@@ -141,7 +142,7 @@ public class DCMFinanceNotification extends FinanceNotification
 
                 String baseUrl = getExecuteQueryUrl(containerMap.get(category), ONPRC_BillingSchema.NAME, categoryToQuery.get(category), null) + "&query.param.StartDate=" + getDateFormat(c).format(start.getTime()) + "&query.param.EndDate=" + getDateFormat(c).format(endDate.getTime());
                 String projUrl = baseUrl + ("None".equals(tokens[0]) ? "&query.project/displayName~isblank" : "&query.project/displayName~eq=" + tokens[0]);
-                msg.append("<tr><td><a href='" + projUrl + "'>" + tokens[0] + "</a></td>");
+                msg.append("<tr><td><a href='" + PageFlowUtil.filter(projUrl) + "'>" + PageFlowUtil.filter(tokens[0]) + "</a></td>");
 
                 //alias
                 String accountUrl = null;
@@ -153,22 +154,22 @@ public class DCMFinanceNotification extends FinanceNotification
 
                 if (accountUrl != null)
                 {
-                    msg.append("<td><a href='" + accountUrl + "'>" + tokens[1] + "</a></td>");
+                    msg.append("<td><a href='" + PageFlowUtil.filter(accountUrl) + "'>" + PageFlowUtil.filter(tokens[1]) + "</a></td>");
                 }
                 else
                 {
-                    msg.append("<td>" + (tokens[1]) + "</td>");
+                    msg.append("<td>" + PageFlowUtil.filter(tokens[1]) + "</td>");
                 }
 
-                msg.append("<td>" + (tokens[2]) + "</td>");
-                msg.append("<td>" + category + "</td>");
+                msg.append("<td>" + PageFlowUtil.filter(tokens[2]) + "</td>");
+                msg.append("<td>" + PageFlowUtil.filter(category) + "</td>");
 
                 for (FieldDescriptor fd : toShow)
                 {
                     if (totals.containsKey(fd.getFieldName()))
                     {
                         String url = projUrl + fd.getFilter();
-                        msg.append("<td" + (fd.isShouldHighlight() ? " style='background-color: yellow;'" : "") + "><a href='" + url + "'>" + totals.get(fd.getFieldName()) + "</a></td>");
+                        msg.append("<td" + (fd.isShouldHighlight() ? " style='background-color: yellow;'" : "") + "><a href='" + PageFlowUtil.filter(url) + "'>" + totals.get(fd.getFieldName()) + "</a></td>");
                     }
                     else
                     {

--- a/onprc_billing/src/org/labkey/onprc_billing/notification/FinanceNotification.java
+++ b/onprc_billing/src/org/labkey/onprc_billing/notification/FinanceNotification.java
@@ -39,6 +39,7 @@ import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.onprc_billing.ONPRC_BillingManager;
 import org.labkey.onprc_billing.ONPRC_BillingModule;
 import org.labkey.onprc_billing.ONPRC_BillingSchema;
@@ -429,7 +430,7 @@ public class FinanceNotification extends AbstractNotification
             Container container = containerMap.get(category);
 
             String url = getExecuteQueryUrl(container, ONPRC_BillingSchema.NAME, categoryToQuery.get(category), null) + "&query.param.StartDate=" + getDateFormat(c).format(start.getTime()) + "&query.param.EndDate=" + getDateFormat(c).format(endDate.getTime());
-            msg.append("<tr><td><a href='" + url + "'>" + category + "</a></td><td>" + totalsMap.get("total") + "</td><td>" + _dollarFormat.format(totalsMap.get("totalCost")) + "</td></tr>");
+            msg.append("<tr><td><a href='" + PageFlowUtil.filter(url) + "'>" + PageFlowUtil.filter(category) + "</a></td><td>" + totalsMap.get("total") + "</td><td>" + _dollarFormat.format(totalsMap.get("totalCost")) + "</td></tr>");
         }
         msg.append("</table><br><br>");
 
@@ -474,8 +475,8 @@ public class FinanceNotification extends AbstractNotification
 
                     String baseUrl = getExecuteQueryUrl(containerMap.get(category), ONPRC_BillingSchema.NAME, categoryToQuery.get(category), null) + "&query.param.StartDate=" + getDateFormat(c).format(start.getTime()) + "&query.param.EndDate=" + getDateFormat(c).format(endDate.getTime());
                     String projUrl = baseUrl + ("None".equals(tokens[1]) ? "&query.project/displayName~isblank" : "&query.project/displayName~eq=" + tokens[1]);
-                    msg.append("<tr><td>" + financialAnalyst + "</td>");    //the FA
-                    msg.append("<td><a href='" + projUrl + "'>" + tokens[1] + "</a></td>");
+                    msg.append("<tr><td>" + PageFlowUtil.filter(financialAnalyst) + "</td>");    //the FA
+                    msg.append("<td><a href='" + PageFlowUtil.filter(projUrl) + "'>" + PageFlowUtil.filter(tokens[1]) + "</a></td>");
 
                     //alias
                     String accountUrl = null;
@@ -487,22 +488,22 @@ public class FinanceNotification extends AbstractNotification
 
                     if (accountUrl != null)
                     {
-                        msg.append("<td><a href='" + accountUrl + "'>" + tokens[2] + "</a></td>");
+                        msg.append("<td><a href='" + PageFlowUtil.filter(accountUrl) + "'>" + PageFlowUtil.filter(tokens[2]) + "</a></td>");
                     }
                     else
                     {
-                        msg.append("<td>" + (tokens[2]) + "</td>");
+                        msg.append("<td>" + PageFlowUtil.filter(tokens[2]) + "</td>");
                     }
 
-                    msg.append("<td>" + (tokens[3]) + "</td>");
-                    msg.append("<td>" + category + "</td>");
+                    msg.append("<td>" + PageFlowUtil.filter(tokens[3]) + "</td>");
+                    msg.append("<td>" + PageFlowUtil.filter(category) + "</td>");
 
                     for (FieldDescriptor fd : foundCols)
                     {
                         if (totals.containsKey(fd.getFieldName()))
                         {
                             String url = projUrl + fd.getFilter();
-                            msg.append("<td" + (fd.isShouldHighlight() ? " style='background-color: yellow;'" : "") + "><a href='" + url + "'>" + totals.get(fd.getFieldName()) + "</a></td>");
+                            msg.append("<td" + (fd.isShouldHighlight() ? " style='background-color: yellow;'" : "") + "><a href='" + PageFlowUtil.filter(url) + "'>" + totals.get(fd.getFieldName()) + "</a></td>");
                         }
                         else
                         {


### PR DESCRIPTION
## Rationale

FinanceNotification.writeResultTable and its overriding subclass DCMFinanceNotification.writeResultTable are divergent copies of the ehr_billing BillingNotification report that concatenated editor-entered database values (investigator, project, alias/account, OGA project number, category) and their derived URLs directly into HTML with no escaping. That HTML is rendered verbatim into the LDK RunNotificationAction admin preview via HtmlString.unsafe and is also sent as the HTML email body, so a stored payload in any of those project/alias fields executed in the browser of any user who previewed the notification or received the email — a stored XSS with privilege-escalation potential toward admins. Both are registered, active notifications (ONPRC_BillingModule). This is the ONPRC counterpart to the BillingNotification fix; unlike that copy, the top category summary table here was also unescaped.

## Related Pull Requests

- LabKey/ehrModules#1159

## Changes

- FinanceNotification: wrap every editor-entered value (investigator, project, account, project number, category) and its derived href URL in PageFlowUtil.filter in the per-financial-analyst tables, and filter the top category summary table (url and category), which was unescaped in this copy.
- DCMFinanceNotification: apply the same filtering to its writeResultTable override, which the parent-class fix did not cover; mapped to this override's token layout (tokens[0] project, tokens[1] alias, tokens[2] OGA project number).
- Add the org.labkey.api.util.PageFlowUtil import to both files.