### PR TITLE
Preserve delete audit records for MHC data

### DIFF
--- a/GeneticsCore/src/org/labkey/GeneticsCore/mhc/MhcTaskRef.java
+++ b/GeneticsCore/src/org/labkey/GeneticsCore/mhc/MhcTaskRef.java
@@ -137,7 +137,7 @@ public class MhcTaskRef implements TaskRefTask
             {
                 job.getLogger().info("deleting existing rows: " + toDelete.size());
                 QueryUpdateService qus = mhcData.getUpdateService();
-                qus.setBulkLoad(true);
+                qus.setBulkLoad(false); //preserve audit trail
                 qus.deleteRows(job.getUser(), getTargetContainer(job), toDelete, null, null);
             }
             catch (InvalidKeyException | BatchValidationException | QueryUpdateServiceException | SQLException e)


### PR DESCRIPTION
@brentlogan: this PR is designed to help the ETL that syncs MHC data from prime-seq to prime. there is currently a loophole that lets some source record deletes get missed. this should fix that. it will be deployed to prime-seq, so doesnt need anything from PRIME. 