### PR TITLE
26.3 fb bsu rounds rewrite

### DIFF
--- a/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
@@ -95,12 +95,13 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
 
                 var row = new LDK.SelectRowsRow(sr);
 
-                if ( row.getValue('category') == 'Alopecia Regrowth' && tempcaseid != row.getValue('caseid')  ) {
+
+                //note: this has been changed to ensure 1 row per case
+                var key = row.getValue('caseid');
+                if ( row.getValue('category') == 'Alopecia Regrowth' && (tempcaseid != key || key == null) ) {
                     newobservation = row.getValue('category');  //load Alopecia Regrowth
                     tempcaseid = row.getValue('caseid');
                 }
-                //note: this has been changed to ensure 1 row per case
-                var key = row.getValue('caseid');
                 if (!previousObsMap[key])
                     previousObsMap[key] = [];
 
@@ -115,7 +116,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                     remark: row.getValue('remark')
                 });
 
-                if (row.getValue('category') == 'Alopecia Score'  && (newobservation != row.getValue('category')) && (row.getValue('remark') == null || row.getValue('remark') == '')) {
+                if (row.getValue('category') == 'Alopecia Score'  && (newobservation == '') && tempcaseid == '' && (row.getValue('remark') == null || row.getValue('remark') == '')) {
                     previousObsMap[key].push({
                         Id: row.getValue('Id'),
                         date: this.recordData.date,
@@ -126,7 +127,8 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                         allProblemCategories:row.getValue('allProblemCategories')
 
                     });
-
+                       newobservation = '';
+                       tempcaseid = '';
                 }
             }, this);
         }

--- a/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
@@ -98,7 +98,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
 
                 //note: this has been changed to ensure 1 row per case
                 var key = row.getValue('caseid');
-                if ( row.getValue('category') == 'Alopecia Regrowth' && (tempcaseid != key || key == null) ) {
+                if ( row.getValue('category') == 'Alopecia Regrowth' && (tempcaseid != key || tempcaseid == '') ) {
                     newobservation = row.getValue('category');  //load Alopecia Regrowth
                     tempcaseid = row.getValue('caseid');
                 }

--- a/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
@@ -95,7 +95,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
 
                 var row = new LDK.SelectRowsRow(sr);
 
-                if ( row.getValue('category') == 'Alopecia Regrowth' ) {
+                if ( row.getValue('category') == 'Alopecia Regrowth' && tempcaseid != row.getValue('caseid')  ) {
                     newobservation = row.getValue('category');  //load Alopecia Regrowth
                     tempcaseid = row.getValue('caseid');
                 }
@@ -114,7 +114,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                     allProblemCategories:row.getValue('allProblemCategories'),
                     remark: row.getValue('remark')
                 });
-                if (row.getValue('category') == 'Alopecia Score' && tempcaseid == row.getValue('caseid') && newobservation != 'Alopecia Regrowth' && (row.getValue('remark') == null || row.getValue('remark') == '')) {
+                if (row.getValue('category') == 'Alopecia Score' && (tempcaseid == row.getValue('caseid') || tempcaseid == null) && (newobservation != row.getValue('category')|| newobservation == null ) && (row.getValue('remark') == null || row.getValue('remark') == '')) {
                     previousObsMap[key].push({
                         Id: row.getValue('Id'),
                         date: this.recordData.date,

--- a/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
@@ -98,9 +98,18 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
 
                 //note: this has been changed to ensure 1 row per case
                 var key = row.getValue('caseid');
-                if ( row.getValue('category') == 'Alopecia Regrowth' && (tempcaseid != key || tempcaseid == '') ) {
-                    newobservation = row.getValue('category');  //load Alopecia Regrowth
-                    tempcaseid = row.getValue('caseid');
+                // if ( row.getValue('category') == 'Alopecia Regrowth' || (tempcaseid != key || tempcaseid == '') ) {
+                    if (  (tempcaseid != key || tempcaseid == '') ) {
+                        if (row.getValue('category') != 'Alopecia Regrowth') {
+                            newobservation = '';
+                            tempcaseid = '';
+                        }
+                        else
+                        {
+                            newobservation = row.getValue('category');  //load Alopecia Regrowth
+                            tempcaseid = row.getValue('caseid');
+                        }
+
                 }
                 if (!previousObsMap[key])
                     previousObsMap[key] = [];

--- a/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
@@ -114,7 +114,8 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                     allProblemCategories:row.getValue('allProblemCategories'),
                     remark: row.getValue('remark')
                 });
-                if (row.getValue('category') == 'Alopecia Score' && (tempcaseid == row.getValue('caseid') || tempcaseid == null) && (newobservation != row.getValue('category')|| newobservation == null ) && (row.getValue('remark') == null || row.getValue('remark') == '')) {
+
+                if (row.getValue('category') == 'Alopecia Score'  && (newobservation != row.getValue('category')) && (row.getValue('remark') == null || row.getValue('remark') == '')) {
                     previousObsMap[key].push({
                         Id: row.getValue('Id'),
                         date: this.recordData.date,

--- a/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
@@ -50,7 +50,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
             requiredVersion: 9.1,
             schemaName: 'study',
             queryName: 'cases',
-            sort: 'Id/curLocation/room,Id/curLocation/cage,Id,remark,allProblemCategories',
+            sort: 'Id/curLocation/room,Id/curLocation/cage,Id,category,remark,allProblemCategories',
             columns: 'Id,objectid,remark,allProblemCategories',
             filterArray: casesFilterArray,
             scope: this,
@@ -86,15 +86,19 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
         }
 
         var previousObsMap = {};
+        var newobservation = '';
+        var tempcaseid = '';
+
         if (this.obsResults && this.obsResults.rows && this.obsResults.rows.length){
             Ext4.Array.forEach(this.obsResults.rows, function(sr){
                 //reset variable
-                var newobservation = '';
-                var newremark = '';
-                var row = new LDK.SelectRowsRow(sr);
-                newobservation = row.getValue('category');
-                newremark = row.getValue('remark');
 
+                var row = new LDK.SelectRowsRow(sr);
+
+                if (tempcaseid != row.getValue('caseid') && row.getValue('category') == 'Alopecia Regrowth' ) {
+                    newobservation = row.getValue('category');  //load Alopecia Regrowth
+                    tempcaseid = row.getValue('caseid');
+                }
                 //note: this has been changed to ensure 1 row per case
                 var key = row.getValue('caseid');
                 if (!previousObsMap[key])
@@ -110,7 +114,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                     allProblemCategories:row.getValue('allProblemCategories'),
                     remark: row.getValue('remark')
                 });
-                if (newobservation == 'Alopecia Score' && (newremark == null || newremark == '')) {
+                if (row.getValue('category') == 'Alopecia Score' && newobservation != 'Alopecia Regrowth' && (row.getValue('remark') == null || row.getValue('remark') == '')) {
                     previousObsMap[key].push({
                         Id: row.getValue('Id'),
                         date: this.recordData.date,
@@ -121,6 +125,8 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                         allProblemCategories:row.getValue('allProblemCategories')
 
                     });
+                       // reset variables
+                       newobservation ='';
 
                 }
             }, this);

--- a/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
+++ b/onprc_ehr/resources/web/onprc_ehr/window/AddBehaviorCasesWindow.js
@@ -95,7 +95,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
 
                 var row = new LDK.SelectRowsRow(sr);
 
-                if (tempcaseid != row.getValue('caseid') && row.getValue('category') == 'Alopecia Regrowth' ) {
+                if ( row.getValue('category') == 'Alopecia Regrowth' ) {
                     newobservation = row.getValue('category');  //load Alopecia Regrowth
                     tempcaseid = row.getValue('caseid');
                 }
@@ -114,7 +114,7 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                     allProblemCategories:row.getValue('allProblemCategories'),
                     remark: row.getValue('remark')
                 });
-                if (row.getValue('category') == 'Alopecia Score' && newobservation != 'Alopecia Regrowth' && (row.getValue('remark') == null || row.getValue('remark') == '')) {
+                if (row.getValue('category') == 'Alopecia Score' && tempcaseid == row.getValue('caseid') && newobservation != 'Alopecia Regrowth' && (row.getValue('remark') == null || row.getValue('remark') == '')) {
                     previousObsMap[key].push({
                         Id: row.getValue('Id'),
                         date: this.recordData.date,
@@ -125,8 +125,6 @@ Ext4.define('ONPRC_EHR.window.AddBehaviorCasesWindow', {
                         allProblemCategories:row.getValue('allProblemCategories')
 
                     });
-                       // reset variables
-                       newobservation ='';
 
                 }
             }, this);


### PR DESCRIPTION
Modified the BSU Rounds template process to prevent auto generating of an "Alopecia Regrowth" when there are
existing Alopecia Regrowth defined to the same case id.